### PR TITLE
polymer-project-config@v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "polymer-project-config",
+  "version": "1.0.0",
+  "description": "reads, validates, and shapes your polymer.json project configuration",
+  "main": "lib/index.js",
+  "typings": "lib/index.d.ts",
+  "author": "The Polymer Project Authors",
+  "license": "BSD-3-Clause",
+  "scripts": {
+    "build": "tsc",
+    "test": "npm run build && mocha --ui tdd"
+  },
+  "dependencies": {
+    "plylog": "^0.4.0"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "mocha": "^3.0.2",
+    "typescript": "^2.0.2"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,213 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as logging from 'plylog';
+
+const logger = logging.getLogger('polymer-project-config');
+
+/**
+ * The default globs for matching all user application source files.
+ */
+export const defaultSourceGlobs = ['src/**/*'];
+
+/**
+ * Resolve any glob to the given path, even if glob
+ * is negative (begins with '!').
+ */
+function resolveGlob(fromPath: string, glob: string): string {
+  if (glob.startsWith('!')) {
+    const includeGlob = glob.substring(1);
+    return '!' + path.resolve(fromPath, includeGlob);
+  } else {
+    return path.resolve(fromPath, glob);
+  }
+}
+
+/**
+ * Given a user-provided options object, check for deprecated options. When one
+ * is found, warn the user and fix if possible.
+ */
+function fixDeprecatedOptions(options: any): ProjectOptions {
+  if (typeof options.sourceGlobs !== 'undefined') {
+    logger.warn('"sourceGlobs" config option has been renamed to "sources" and will no longer be supported in future versions');
+    options.sources = options.sources || options.sourceGlobs;
+  }
+  if (typeof options.includeDependencies !== 'undefined') {
+    logger.warn('"includeDependencies" config option has been renamed to "dependencies" and will no longer be supported in future versions');
+    options.dependencies = options.dependencies || options.includeDependencies;
+  }
+  return options;
+}
+
+
+export interface ProjectOptions {
+  /**
+   * Path to the root of the project on the filesystem. This can be an absolute
+   * path, or a path relative to the current working directory. Defaults to the
+   * current working directory of the process.
+   */
+  root?: string;
+
+  /**
+   * The path relative to `root` of the entrypoint file that will be served for
+   * app-shell style projects. Usually this is index.html.
+   */
+  entrypoint?: string;
+
+  /**
+   * The path relative to `root` of the app shell element.
+   */
+  shell?: string;
+
+  /**
+   * The path relative to `root` of the lazily loaded fragments. Usually the
+   * pages of an app or other bundles of on-demand resources.
+   */
+  fragments?: string[];
+
+  /**
+   * List of glob patterns, relative to root, of this project's sources to read
+   * from the file system.
+   */
+  sources?: string[];
+
+  /**
+   * List of file paths, relative to the project directory, that should be included
+   * as dependencies in the build target.
+   */
+  dependencies?: string[];
+}
+
+export class ProjectConfig {
+
+  readonly root: string;
+  readonly entrypoint: string;
+  readonly shell: string;
+  readonly fragments: string[];
+  readonly sources: string[];
+  readonly dependencies: string[];
+
+  readonly allFragments: string[];
+
+  /**
+   * Given an absolute file path to a polymer.json-like ProjectOptions object,
+   * read that file. If no file exists, null is returned. If the file exists
+   * but there is a problem reading or parsing it, throw an exception.
+   */
+  static loadOptionsFromFile(filepath: string): ProjectOptions {
+    let configParsed: ProjectOptions;
+    try {
+      const configContent = fs.readFileSync(filepath, 'utf-8');
+      configParsed = JSON.parse(configContent);
+    } catch (error) {
+      // swallow "not found" errors because they are so common / expected
+      if (error.code === 'ENOENT') {
+        logger.debug('no polymer config file found', {file: filepath});
+        return null;
+      }
+      // otherwise, throw an exception
+      throw error;
+    }
+
+    return configParsed;
+  }
+
+  /**
+   * Given an absolute file path to a polymer.json-like ProjectOptions object,
+   * return a new ProjectConfig instance created with those options.
+   */
+  static loadConfigFromFile(filepath: string): ProjectConfig {
+    let configParsed = ProjectConfig.loadOptionsFromFile(filepath);
+    if (!configParsed) {
+      return null;
+    }
+    return new ProjectConfig(configParsed);
+  }
+
+  /**
+   * constructor - given a ProjectOptions object, create the correct project
+   * configuration for those options. This involves setting the correct
+   * defaults, validating options, warning on deprecated options, and
+   * calculating some additional properties.
+   */
+  constructor(options: ProjectOptions) {
+    options = options || {};
+    options = fixDeprecatedOptions(options);
+
+    /**
+     * root
+     */
+    if (options.root) {
+      this.root = path.resolve(options.root);
+    } else {
+      this.root = process.cwd();
+    }
+
+    /**
+     * entrypoint
+     */
+    if (options.entrypoint) {
+      this.entrypoint = path.resolve(this.root, options.entrypoint);
+    } else {
+      this.entrypoint = path.resolve(this.root, 'index.html');
+    }
+
+    /**
+     * shell
+     */
+    if (options.shell) {
+      this.shell = path.resolve(this.root, options.shell);
+    }
+
+    /**
+     * fragments
+     */
+    if (options.fragments) {
+      this.fragments = options.fragments.map((e) => path.resolve(this.root, e));
+    }
+
+    /**
+     * dependencies
+     */
+    this.dependencies = (options.dependencies || [])
+        .map((glob) => resolveGlob(this.root, glob));
+
+    /**
+     * sources
+     */
+    this.sources = (options.sources || defaultSourceGlobs)
+        .map((glob) => resolveGlob(this.root, glob));
+    this.sources.push(this.entrypoint);
+    if (this.shell) {
+      this.sources.push(this.shell);
+    }
+    if (this.fragments) {
+      this.sources = this.sources.concat(this.fragments);
+    }
+
+    /**
+     * allFragments
+     */
+    this.allFragments = [];
+    // It's important that shell is first for document-ordering of imports
+    if (this.shell) {
+      this.allFragments.push(this.shell);
+    }
+    if (this.fragments) {
+      this.allFragments = this.allFragments.concat(this.fragments);
+    }
+    if (this.allFragments.length === 0) {
+      this.allFragments.push(this.entrypoint);
+    }
+  }
+
+}

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -1,0 +1,249 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+'use strict';
+const assert = require('chai').assert;
+const path = require('path');
+const ProjectConfig = require('..').ProjectConfig;
+
+suite('Project Config', () => {
+
+  suite('ProjectConfig', () => {
+
+    test('sets minimum set of defaults when no options are provided', () => {
+      const absoluteRoot = process.cwd();
+      const config = new ProjectConfig();
+      assert.deepEqual(config, {
+        root: absoluteRoot,
+        entrypoint: path.resolve(absoluteRoot, 'index.html'),
+        allFragments: [path.resolve(absoluteRoot, 'index.html')],
+        dependencies: [],
+        sources: [
+          path.resolve(absoluteRoot, 'src/**/*'),
+          path.resolve(absoluteRoot, 'index.html'),
+        ],
+      });
+    });
+
+    test('sets root relative to current working directory when provided', () => {
+      const relativeRoot = 'public';
+      const absoluteRoot = path.resolve(relativeRoot);
+      const config = new ProjectConfig({root: relativeRoot});
+      assert.deepEqual(config, {
+        root: absoluteRoot,
+        entrypoint: path.resolve(absoluteRoot, 'index.html'),
+        allFragments: [path.resolve(absoluteRoot, 'index.html')],
+        dependencies: [],
+        sources: [
+          path.resolve(absoluteRoot, 'src/**/*'),
+          path.resolve(absoluteRoot, 'index.html'),
+        ],
+      });
+    });
+
+    test('sets entrypoint relative to root when provided', () => {
+      const relativeRoot = 'public';
+      const absoluteRoot = path.resolve(relativeRoot);
+      const config = new ProjectConfig({
+        root: relativeRoot,
+        entrypoint: 'foo.html'
+      });
+      assert.deepEqual(config, {
+        root: absoluteRoot,
+        entrypoint: path.resolve(absoluteRoot, 'foo.html'),
+        allFragments: [path.resolve(absoluteRoot, 'foo.html')],
+        dependencies: [],
+        sources: [
+          path.resolve(absoluteRoot, 'src/**/*'),
+          path.resolve(absoluteRoot, 'foo.html'),
+        ],
+      });
+    });
+
+    test('sets shell relative to root when provided', () => {
+      const config = new ProjectConfig({
+        shell: 'foo.html'
+      });
+      assert.deepEqual(config, {
+        root: process.cwd(),
+        entrypoint: path.resolve('index.html'),
+        shell: path.resolve('foo.html'),
+        allFragments: [
+          path.resolve('foo.html')
+        ],
+        dependencies: [],
+        sources: [
+          path.resolve('src/**/*'),
+          path.resolve('index.html'),
+          path.resolve('foo.html')
+        ],
+      });
+    });
+
+    test('sets fragments relative to root when provided', () => {
+      const config = new ProjectConfig({
+        fragments: ['foo.html', 'bar.html']
+      });
+      assert.deepEqual(config, {
+        root: process.cwd(),
+        entrypoint: path.resolve('index.html'),
+        fragments: [
+          path.resolve('foo.html'),
+          path.resolve('bar.html'),
+        ],
+        allFragments: [
+          path.resolve('foo.html'),
+          path.resolve('bar.html'),
+        ],
+        dependencies: [],
+        sources: [
+          path.resolve('src/**/*'),
+          path.resolve('index.html'),
+          path.resolve('foo.html'),
+          path.resolve('bar.html'),
+        ],
+      });
+    });
+
+    test('adds sources relative to root when provided', () => {
+      const relativeRoot = 'public';
+      const absoluteRoot = path.resolve(relativeRoot);
+      const config = new ProjectConfig({
+        root: relativeRoot,
+        sources: ['src/**/*', 'images/**/*']
+      });
+      assert.deepEqual(config, {
+        root: absoluteRoot,
+        entrypoint: path.resolve(absoluteRoot, 'index.html'),
+        allFragments: [path.resolve(absoluteRoot, 'index.html')],
+        dependencies: [],
+        sources: [
+          path.resolve(absoluteRoot, 'src/**/*'),
+          path.resolve(absoluteRoot, 'images/**/*'),
+          path.resolve(absoluteRoot, 'index.html'),
+        ],
+      });
+    });
+
+    test('sets dependencies relative to root when provided', () => {
+      const relativeRoot = 'public';
+      const absoluteRoot = path.resolve(relativeRoot);
+      const config = new ProjectConfig({
+        root: relativeRoot,
+        dependencies: [
+          'bower_components/**/*.js',
+          '!bower_components/ignore-big-package',
+        ],
+      });
+      assert.deepEqual(config, {
+        root: absoluteRoot,
+        entrypoint: path.resolve(absoluteRoot, 'index.html'),
+        allFragments: [path.resolve(absoluteRoot, 'index.html')],
+        dependencies: [
+          path.resolve(absoluteRoot, 'bower_components/**/*.js'),
+          '!' + path.resolve(absoluteRoot, 'bower_components/ignore-big-package'),
+        ],
+        sources: [
+          path.resolve(absoluteRoot, 'src/**/*'),
+          path.resolve(absoluteRoot, 'index.html'),
+        ],
+      });
+    });
+
+    test('sets allFragments to fragments & shell when both are provided', () => {
+      const config = new ProjectConfig({
+        fragments: ['foo.html', 'bar.html'],
+        shell: 'baz.html',
+      });
+      assert.deepEqual(config, {
+        root: process.cwd(),
+        entrypoint: path.resolve('index.html'),
+        shell: path.resolve('baz.html'),
+        fragments: [
+          path.resolve('foo.html'),
+          path.resolve('bar.html'),
+        ],
+        allFragments: [
+          path.resolve('baz.html'),
+          path.resolve('foo.html'),
+          path.resolve('bar.html'),
+        ],
+        dependencies: [],
+        sources: [
+          path.resolve('src/**/*'),
+          path.resolve('index.html'),
+          path.resolve('baz.html'),
+          path.resolve('foo.html'),
+          path.resolve('bar.html'),
+        ],
+      });
+    });
+
+  });
+
+  suite('loadOptionsFromFile()', () => {
+
+    test('throws an exception for invalid polymer.json', () => {
+      const filepath = path.join(__dirname, 'polymer-invalid.json');
+      assert.throws(() => ProjectConfig.loadOptionsFromFile(filepath));
+    });
+
+    test('returns null if file is missing', () => {
+      const filepath = path.join(__dirname, 'this-file-does-not-exist.json');
+      assert.equal(ProjectConfig.loadOptionsFromFile(filepath), null);
+    });
+
+    test('reads options from config file', () => {
+      const options = ProjectConfig.loadOptionsFromFile(path.join(__dirname, 'polymer.json'));
+      assert.deepEqual(options, {
+        root: 'public',
+        entrypoint: 'foo.html',
+        fragments: ['bar.html'],
+        dependencies: ['baz.html'],
+        sources: ['src/**/*', 'images/**/*'],
+      });
+    });
+
+  });
+
+  suite('loadConfigFromFile()', () => {
+
+    test('throws an exception for invalid polymer.json', () => {
+      const filepath = path.join(__dirname, 'polymer-invalid.json');
+      assert.throws(() => ProjectConfig.loadConfigFromFile(filepath));
+    });
+
+    test('returns null if file is missing', () => {
+      const filepath = path.join(__dirname, 'this-file-does-not-exist.json');
+      assert.equal(ProjectConfig.loadConfigFromFile(filepath), null);
+    });
+
+    test('creates config instance from config file options', () => {
+      const config = ProjectConfig.loadConfigFromFile(path.join(__dirname, 'polymer.json'));
+      const relativeRoot = 'public';
+      const absoluteRoot = path.resolve(relativeRoot);
+      assert.deepEqual(config, {
+        root: absoluteRoot,
+        entrypoint: path.resolve(absoluteRoot, 'foo.html'),
+        fragments: [path.resolve(absoluteRoot, 'bar.html')],
+        allFragments: [path.resolve(absoluteRoot, 'bar.html')],
+        dependencies: [path.resolve(absoluteRoot, 'baz.html')],
+        sources: [
+          path.resolve(absoluteRoot, 'src/**/*'),
+          path.resolve(absoluteRoot, 'images/**/*'),
+          path.resolve(absoluteRoot, 'foo.html'),
+          path.resolve(absoluteRoot, 'bar.html'),
+        ]
+      });
+    });
+
+  });
+
+});

--- a/test/polymer-invalid.json
+++ b/test/polymer-invalid.json
@@ -1,0 +1,6 @@
+{
+  "entrypoint": "foo.html",
+  "fragments": [
+    "bar.html",
+  ]
+}

--- a/test/polymer.json
+++ b/test/polymer.json
@@ -1,0 +1,14 @@
+{
+  "root": "public",
+  "entrypoint": "foo.html",
+  "fragments": [
+    "bar.html"
+  ],
+  "dependencies": [
+    "baz.html"
+  ],
+  "sources": [
+    "src/**/*",
+    "images/**/*"
+  ]
+}


### PR DESCRIPTION
This PR pulls out and standardizes all logic from polymer-cli & polymer-build that had to do with polymer.json reading, parsing, and validation. The expected polymer.json format was starting to diverge between libraries, and some properties were being handled/parsed differently between changes.

This PR also takes the opportunity to make some changes to the polymer.json format that we've been meaning to make for a while (but were blocked by the dual-nature of -build/-cli parsing). polymer-project-config has been written to be as non-breaking as possible from current behavior, and continuing to support deprecated polymer.json fields /w a deprecation warning.

### problems being solved

1. Builds fail for users who don't use the `src/` directory (fragments not found in `src/`).
1. Users have to define all sources in `sourceGlobs` including files already described in fragments. It would be less confusing and easier to configure if `sourceGlobs` behaved like `includeDependencies` by just adding to (instead of overwriting) the list of files we already know about.
1. `sources` vs. `dependencies` is confusing and arbitrary for users of the CLI.
 
### major changes

- **`sourceGlobs` is now `sources`:** Name bikeshedding welcome, but including "globs" in the name felt unnecessarily Hungarian :)
- **`includeDependencies` is now just `dependencies`:** More bikeshedding welcome, but the background is that people were finding the "include" part of the name confusing/vague. `dependencies` now matches simple naming of`sources`.
- Old naming is still supported but deprecated (via warning).

### breaking changes

- __`sources` default behavior changed:__ Previously, sources has been a required collection of globs that needed to match all source files in your application. This caused confusion for many users and actual build problems for many others. Now `sources` defaults to an array of your shell, entrypoint, and fragments. This should continue to work for most users (doesn't break any cli templates) but may break for some users who were dynamically loading files out of their src/ directory without defining their own `sources` property.

### other interesting changes / implications

- `dependencies` vs. `sources` now have much more concrete purposes. Sources are fragments of the application (+ explicitly added files), and dependencies are files loaded/needed by those files.
- Because of this, `dependencies` should now be the default property that a CLI user adds missing file paths to. Polymer build users can add wherever they want, based on their configuration.


### still todo (later PRs)

- new polymer-project-config README
- docs: new page dedicated to polymer.json which all other areas could reference. Think https://docs.npmjs.com/files/package.json
- docs & READMEs: point all current little polymer.json doc snippets to new page
- docs: new page dedicated to building! Same page that describes polymer.json?

/cc @justinfagnani @robdodson 