### PR TITLE
add isSource() method to check against source globs

### DIFF
--- a/custom_typings/minimatch-all.d.ts
+++ b/custom_typings/minimatch-all.d.ts
@@ -1,0 +1,7 @@
+declare module 'minimatch-all' {
+
+  function minimatchAll(filePath: string, globs: string[])
+      : boolean;
+
+  export = minimatchAll;
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@types/node": "^6.0.41",
+    "minimatch-all": "^1.1.0",
     "plylog": "^0.4.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as logging from 'plylog';
+import minimatchAll = require('minimatch-all');
 
 const logger = logging.getLogger('polymer-project-config');
 
@@ -225,6 +226,10 @@ export class ProjectConfig {
 
   isShell(filepath: string): boolean {
     return (!!this.shell && (this.shell === filepath));
+  }
+
+  isSource(filepath: string): boolean {
+    return minimatchAll(filepath, this.sources);
   }
 
   /**

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -238,6 +238,27 @@ suite('Project Config', () => {
 
     });
 
+    suite('isSource()', () => {
+
+      test('matches source file paths and does not match other file paths', () => {
+        const relativeRoot = 'public';
+        const absoluteRoot = path.resolve(relativeRoot);
+        const config = new ProjectConfig({
+          root: relativeRoot,
+          entrypoint: 'foo.html',
+          fragments: ['bar.html'],
+          shell: 'baz.html',
+        });
+        assert.isTrue(config.isSource(config.entrypoint));
+        assert.isTrue(config.isSource(config.shell));
+        assert.isTrue(config.isSource(path.resolve(absoluteRoot, 'foo.html')));
+        assert.isTrue(config.isSource(path.resolve(absoluteRoot, 'bar.html')));
+        assert.isTrue(config.isSource(path.resolve(absoluteRoot, 'baz.html')));
+        assert.isFalse(config.isSource(path.resolve(absoluteRoot, 'not-a-fragment.html')));
+      });
+
+    });
+
     suite('validate()', () => {
 
       test('returns true for valid configuration', () => {


### PR DESCRIPTION
In polymer-build we have had to write our own check to see if a file is a source file or not. Instead lets provide this as a helper method similar to `isShell()` and `isFragment()`.

/cc @justinfagnani @usergenic 