### PR TITLE
Add support for build config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,10 @@ export interface ProjectOptions {
    */
   extraDependencies?: string[];
 
-  build?: ProjectBuildOptions|ProjectBuildOptions[];
+  /**
+   * List of build option configurations.
+   */
+  builds?: ProjectBuildOptions[];
 }
 
 export class ProjectConfig {
@@ -161,7 +164,6 @@ export class ProjectConfig {
    */
   constructor(options: ProjectOptions) {
     options = (options) ? fixDeprecatedOptions(options) : {};
-
     /**
      * root
      */
@@ -233,10 +235,8 @@ export class ProjectConfig {
     /**
      * builds
      */
-    if (Array.isArray(options.build)) {
-      this.builds = options.build;
-    } else if (options.build) {
-      this.builds = [options.build];
+    if (options.builds) {
+      this.builds = options.builds;
     }
   }
 
@@ -283,6 +283,10 @@ export class ProjectConfig {
 
     // TODO(fks) 11-14-2016: Validate that files actually exist in the file
     // system. Potentially become async function for this.
+    console.assert(
+      !this.builds || Array.isArray(this.builds),
+      `${validateErrorPrefix}: "builds" (${this.builds}) ` +
+      `expected an array of build configurations.`);
 
     return true;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -290,10 +290,14 @@ export class ProjectConfig {
         Array.isArray(this.builds),
         `${validateErrorPrefix}: "builds" (${this.builds}) ` +
         `expected an array of build configurations.`);
-      const buildNames = new Set<string>();
-      for (const build of this.builds) {
-        const buildName = build.name;
-        if (buildName) {
+
+      if (this.builds.length > 1) {
+        const buildNames = new Set<string>();
+        for (const build of this.builds) {
+          const buildName = build.name;
+          console.assert(buildName,
+            `${validateErrorPrefix}: all "builds" require a "name" property ` +
+            `when there are multiple builds defined.`);
           console.assert(!buildNames.has(buildName),
             `${validateErrorPrefix}: "builds" duplicate build name ` +
             `"${buildName}" found. Build names must be unique.`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,7 @@ function fixDeprecatedOptions(options: any): ProjectOptions {
 }
 
 export interface ProjectBuildOptions {
+  name?: string;
   addServiceWorker?: boolean;
   swPrecacheConfig?: string;
   insertPrefetchLinks?: boolean;
@@ -283,10 +284,23 @@ export class ProjectConfig {
 
     // TODO(fks) 11-14-2016: Validate that files actually exist in the file
     // system. Potentially become async function for this.
-    console.assert(
-      !this.builds || Array.isArray(this.builds),
-      `${validateErrorPrefix}: "builds" (${this.builds}) ` +
-      `expected an array of build configurations.`);
+
+    if (this.builds) {
+      console.assert(
+        Array.isArray(this.builds),
+        `${validateErrorPrefix}: "builds" (${this.builds}) ` +
+        `expected an array of build configurations.`);
+      const buildNames = new Set<string>();
+      for (const build of this.builds) {
+        const buildName = build.name;
+        if (buildName) {
+          console.assert(!buildNames.has(buildName),
+            `${validateErrorPrefix}: "builds" duplicate build name ` +
+            `"${buildName}" found. Build names must be unique.`);
+          buildNames.add(buildName);
+        }
+      }
+    }
 
     return true;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,15 @@ function fixDeprecatedOptions(options: any): ProjectOptions {
   return options;
 }
 
+export interface ProjectBuildOptions {
+  addServiceWorker?: boolean;
+  swPrecacheConfig?: string;
+  insertPrefetchLinks?: boolean;
+  bundle?: boolean;
+  html?: {minify: boolean};
+  css?: {minify: boolean};
+  js?: {minify?: boolean, compile?: boolean};
+}
 
 export interface ProjectOptions {
   /**
@@ -96,6 +105,8 @@ export interface ProjectOptions {
    * as extraDependencies in the build target.
    */
   extraDependencies?: string[];
+
+  build?: ProjectBuildOptions|ProjectBuildOptions[];
 }
 
 export class ProjectConfig {
@@ -107,6 +118,7 @@ export class ProjectConfig {
   readonly sources: string[];
   readonly extraDependencies: string[];
 
+  readonly builds: ProjectBuildOptions[];
   readonly allFragments: string[];
 
   /**
@@ -216,6 +228,15 @@ export class ProjectConfig {
     }
     if (this.allFragments.length === 0) {
       this.allFragments.push(this.entrypoint);
+    }
+
+    /**
+     * builds
+     */
+    if (Array.isArray(options.build)) {
+      this.builds = options.build;
+    } else if (options.build) {
+      this.builds = [options.build];
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,8 +64,8 @@ export interface ProjectBuildOptions {
   swPrecacheConfig?: string;
   insertPrefetchLinks?: boolean;
   bundle?: boolean;
-  html?: {minify: boolean};
-  css?: {minify: boolean};
+  html?: {minify?: boolean};
+  css?: {minify?: boolean};
   js?: {minify?: boolean, compile?: boolean};
 }
 

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -22,6 +22,7 @@ suite('Project Config', () => {
       test('sets minimum set of defaults when no options are provided', () => {
         const absoluteRoot = process.cwd();
         const config = new ProjectConfig();
+        config.validate();
 
         assert.deepEqual(config, {
           root: absoluteRoot,
@@ -40,6 +41,8 @@ suite('Project Config', () => {
         const relativeRoot = 'public';
         const absoluteRoot = path.resolve(relativeRoot);
         const config = new ProjectConfig({root: relativeRoot});
+        config.validate();
+
         assert.deepEqual(config, {
           root: absoluteRoot,
           entrypoint: path.resolve(absoluteRoot, 'index.html'),
@@ -60,6 +63,8 @@ suite('Project Config', () => {
           root: relativeRoot,
           entrypoint: 'foo.html'
         });
+        config.validate();
+
         assert.deepEqual(config, {
           root: absoluteRoot,
           entrypoint: path.resolve(absoluteRoot, 'foo.html'),
@@ -77,6 +82,8 @@ suite('Project Config', () => {
         const config = new ProjectConfig({
           shell: 'foo.html'
         });
+        config.validate();
+
         assert.deepEqual(config, {
           root: process.cwd(),
           entrypoint: path.resolve('index.html'),
@@ -98,6 +105,8 @@ suite('Project Config', () => {
         const config = new ProjectConfig({
           fragments: ['foo.html', 'bar.html']
         });
+        config.validate();
+
         assert.deepEqual(config, {
           root: process.cwd(),
           entrypoint: path.resolve('index.html'),
@@ -126,6 +135,8 @@ suite('Project Config', () => {
           root: relativeRoot,
           sources: ['src/**/*', 'images/**/*']
         });
+        config.validate();
+
         assert.deepEqual(config, {
           root: absoluteRoot,
           entrypoint: path.resolve(absoluteRoot, 'index.html'),
@@ -150,6 +161,8 @@ suite('Project Config', () => {
             '!bower_components/ignore-big-package',
           ],
         });
+        config.validate();
+
         assert.deepEqual(config, {
           root: absoluteRoot,
           entrypoint: path.resolve(absoluteRoot, 'index.html'),
@@ -171,6 +184,8 @@ suite('Project Config', () => {
           fragments: ['foo.html', 'bar.html'],
           shell: 'baz.html',
         });
+        config.validate();
+
         assert.deepEqual(config, {
           root: process.cwd(),
           entrypoint: path.resolve('index.html'),
@@ -198,6 +213,8 @@ suite('Project Config', () => {
       test('builds property is unset when `build` option is not provided', () => {
         const absoluteRoot = process.cwd();
         const config = new ProjectConfig();
+        config.validate();
+
         assert.isUndefined(config.builds);
       });
 
@@ -217,6 +234,8 @@ suite('Project Config', () => {
             }
           ]
         });
+        config.validate();
+
         assert.property(config, 'builds');
         assert.deepEqual(config.builds, [
           {
@@ -244,6 +263,8 @@ suite('Project Config', () => {
           fragments: ['bar.html'],
           shell: 'baz.html',
         });
+        config.validate();
+
         assert.isTrue(config.isFragment(config.shell));
         assert.isTrue(config.isFragment(path.resolve(absoluteRoot, 'bar.html')));
         assert.isTrue(config.isFragment(path.resolve(absoluteRoot, 'baz.html')));
@@ -265,6 +286,8 @@ suite('Project Config', () => {
           fragments: ['bar.html'],
           shell: 'baz.html',
         });
+        config.validate();
+
         assert.isFalse(config.isShell(config.entrypoint));
         assert.isTrue(config.isShell(config.shell));
         assert.isFalse(config.isShell(path.resolve(absoluteRoot, 'foo.html')));
@@ -419,6 +442,8 @@ suite('Project Config', () => {
 
     test('creates config instance from config file options', () => {
       const config = ProjectConfig.loadConfigFromFile(path.join(__dirname, 'polymer.json'));
+      config.validate();
+
       const relativeRoot = 'public';
       const absoluteRoot = path.resolve(relativeRoot);
       assert.deepEqual(config, {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -194,27 +194,16 @@ suite('Project Config', () => {
         });
       });
 
-      test('sets builds property to an array when `build` option is a single build object', () => {
+      test('builds property is unset when `build` option is not provided', () => {
         const absoluteRoot = process.cwd();
-        const config = new ProjectConfig({
-          build: {
-            name: 'bundled',
-            bundle: true,
-            insertPrefetchLinks: true,
-          }
-        });
-        assert.property(config, 'builds');
-        assert.deepEqual(config.builds, [{
-          name: 'bundled',
-          bundle: true,
-          insertPrefetchLinks: true,
-        }]);
+        const config = new ProjectConfig();
+        assert.isUndefined(config.builds);
       });
 
       test('sets builds property to an array when `build` option is an array', () => {
         const absoluteRoot = process.cwd();
         const config = new ProjectConfig({
-          build: [
+          builds: [
             {
               name: 'bundled',
               bundle: true,
@@ -358,6 +347,18 @@ suite('Project Config', () => {
         assert.throws(() => config.validate(), /AssertionError: Polymer Config Error: shell \(.*bar.html\) does not resolve within root \(.*public\)/);
       });
 
+
+      test('throws an exception when builds property was not an array', () => {
+        const absoluteRoot = process.cwd();
+        const config = new ProjectConfig({
+          builds: {
+            name: 'bundled',
+            bundle: true,
+            insertPrefetchLinks: true,
+          }
+        });
+        assert.throws(() => config.validate(), /AssertionError: Polymer Config Error: "builds" \(\[object Object\]\) expected an array of build configurations\./);
+      });
     });
 
   });

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -194,6 +194,53 @@ suite('Project Config', () => {
         });
       });
 
+      test('sets builds property to an array when `build` option is a single build object', () => {
+        const absoluteRoot = process.cwd();
+        const config = new ProjectConfig({
+          build: {
+            name: 'bundled',
+            bundle: true,
+            insertPrefetchLinks: true,
+          }
+        });
+        assert.property(config, 'builds');
+        assert.deepEqual(config.builds, [{
+          name: 'bundled',
+          bundle: true,
+          insertPrefetchLinks: true,
+        }]);
+      });
+
+      test('sets builds property to an array when `build` option is an array', () => {
+        const absoluteRoot = process.cwd();
+        const config = new ProjectConfig({
+          build: [
+            {
+              name: 'bundled',
+              bundle: true,
+              insertPrefetchLinks: true,
+            },
+            {
+              name: 'unbundled',
+              bundle: false,
+              insertPrefetchLinks: true,
+            }
+          ]
+        });
+        assert.property(config, 'builds');
+        assert.deepEqual(config.builds, [
+          {
+            name: 'bundled',
+            bundle: true,
+            insertPrefetchLinks: true,
+          },
+          {
+            name: 'unbundled',
+            bundle: false,
+            insertPrefetchLinks: true,
+          }
+        ]);
+      });
     });
 
     suite('isFragment()', () => {

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -22,6 +22,7 @@ suite('Project Config', () => {
       test('sets minimum set of defaults when no options are provided', () => {
         const absoluteRoot = process.cwd();
         const config = new ProjectConfig();
+
         assert.deepEqual(config, {
           root: absoluteRoot,
           entrypoint: path.resolve(absoluteRoot, 'index.html'),
@@ -347,7 +348,6 @@ suite('Project Config', () => {
         assert.throws(() => config.validate(), /AssertionError: Polymer Config Error: shell \(.*bar.html\) does not resolve within root \(.*public\)/);
       });
 
-
       test('throws an exception when builds property was not an array', () => {
         const absoluteRoot = process.cwd();
         const config = new ProjectConfig({
@@ -358,6 +358,23 @@ suite('Project Config', () => {
           }
         });
         assert.throws(() => config.validate(), /AssertionError: Polymer Config Error: "builds" \(\[object Object\]\) expected an array of build configurations\./);
+      });
+
+      test('throws an exception when builds array contains duplicate names', () => {
+        const absoluteRoot = process.cwd();
+        const config = new ProjectConfig({
+          builds: [
+            {
+              name: 'bundled',
+              bundle: true,
+            },
+            {
+              name: 'bundled',
+              bundle: false,
+            }
+          ]
+        });
+        assert.throws(() => config.validate(), /AssertionError: Polymer Config Error: "builds" duplicate build name "bundled" found. Build names must be unique\./);
       });
     });
 

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -371,6 +371,21 @@ suite('Project Config', () => {
         assert.throws(() => config.validate(), /AssertionError: Polymer Config Error: shell \(.*bar.html\) does not resolve within root \(.*public\)/);
       });
 
+      test('returns true when a single, unnamed build is defined', () => {
+        const relativeRoot = 'public';
+        const absoluteRoot = path.resolve(relativeRoot);
+        const config = new ProjectConfig({
+          root: relativeRoot,
+          builds: [{
+            bundle: true,
+            insertPrefetchLinks: true,
+          }],
+        });
+
+        const validateResult = config.validate();
+        assert.isTrue(validateResult);
+      });
+
       test('throws an exception when builds property was not an array', () => {
         const absoluteRoot = process.cwd();
         const config = new ProjectConfig({
@@ -399,6 +414,23 @@ suite('Project Config', () => {
         });
         assert.throws(() => config.validate(), /AssertionError: Polymer Config Error: "builds" duplicate build name "bundled" found. Build names must be unique\./);
       });
+
+      test('throws an exception when builds array contains an unnamed build', () => {
+        const absoluteRoot = process.cwd();
+        const config = new ProjectConfig({
+          builds: [
+            {
+              bundle: true,
+            },
+            {
+              name: 'bundled',
+              bundle: false,
+            }
+          ]
+        });
+        assert.throws(() => config.validate(), /AssertionError: Polymer Config Error: all "builds" require a "name" property when there are multiple builds defined\./);
+      });
+
     });
 
   });


### PR DESCRIPTION
This PR adds support for build configuration options as outlined in our [Build Permutations Design Doc](https://docs.google.com/document/d/1mD1cVhxdxY-bUsGBX44anC1875Afx7UHue4uRCNVc4o). 

This work is necessary for Polymer CLI support to define build(s) in `polymer.json`.