### PR TITLE
add build preset support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
+  - "node"
   - "6"
-  - "5"
-  - "4"
 sudo: false
 before_script:
   - npm install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   User-visible changes must be documented here. Uncomment the Unreleased heading
   as appropriate too.
 -->
+* Add build preset support.
+
 
 ## [2.1.1] - 2017-04-14
 * Add more documentation, and expose it through the JSON Schema.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   as appropriate too.
 -->
 * Add build preset support.
+* Remove Node v4 support: Node v4 is no longer in Active LTS, so as per the [Polymer Tools Node.js Support Policy](https://www.polymer-project.org/2.0/docs/tools/node-support) we will not support Node v4 going forward. Please update to Node v6 or later to continue using the latest verisons of Polymer tooling.
 
 
 ## [2.1.1] - 2017-04-14

--- a/src/builds.ts
+++ b/src/builds.ts
@@ -1,0 +1,162 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+
+export interface ProjectBuildOptions {
+  /**
+   * The name of this build, used to determine the output directory name.
+   */
+  name?: string;
+
+  /**
+   * A build preset for this build. A build can inherit some base configuration from a named preset.
+   */
+  preset?: string;
+
+  /**
+   * Generate a service worker for your application to cache all files and
+   * assets on the client.
+   *
+   * Polymer CLI will generate a service worker for your build using the
+   * [sw-precache library](https://github.com/GoogleChrome/sw-precache). To
+   * customize your service worker, create a sw-precache-config.js file in your
+   * project directory that exports your configuration. See the [sw-precache
+   * README](https://github.com/GoogleChrome/sw-precache) for a list of all
+   * supported options.
+   *
+   * Note that the sw-precache library uses a cache-first strategy for maximum
+   * speed and makes some other assumptions about how your service worker should
+   * behave. Read the "Considerations" section of the sw-precache README to make
+   * sure that this is suitable for your application.
+   */
+  addServiceWorker?: boolean;
+
+  /**
+   * If `true`, generate an [HTTP/2 Push
+   * Manifest](https://github.com/GoogleChrome/http2-push-manifest) for your
+   * application.
+   */
+  addPushManifest?: boolean;
+
+  /**
+   * A config file that's passed to the [sw-precache
+   * library](https://github.com/GoogleChrome/sw-precache). See [its
+   * README](https://github.com/GoogleChrome/sw-precache) for details of the
+   * format of this file.
+   *
+   * Ignored if `addServiceWorker` is not `true`.
+   *
+   * Defaults to `"sw-precache-config.js`.
+   */
+  swPrecacheConfig?: string;
+
+  /**
+   * Insert prefetch link elements into your fragments so that all dependencies
+   * are prefetched immediately. Add dependency prefetching by inserting `<link
+   * rel="prefetch">` tags into entrypoint and `<link rel="import">` tags into
+   * fragments and shell for all dependencies.
+   */
+  insertPrefetchLinks?: boolean;
+
+  /**
+   * By default, fragments are unbundled. This is optimal for HTTP/2-compatible
+   * servers and clients.
+   *
+   * If the --bundle flag is supplied, all fragments are bundled together to
+   * reduce the number of file requests. This is optimal for sending to clients
+   * or serving from servers that are not HTTP/2 compatible.
+   */
+  bundle?: boolean;
+
+  /** Options for processing HTML. */
+  html?: {
+    /** Minify HTMl by removing comments and whitespace. */
+    minify?: boolean
+  };
+
+  /** Options for processing CSS. */
+  css?: {
+    /** Minify inlined and external CSS. */
+    minify?: boolean
+  };
+
+  /** Options for processing JavaScript. */
+  js?: {
+    /** Minify inlined and external JavaScript. */
+    minify?: boolean,
+
+    /** Use babel to compile all ES6 JS down to ES5 for older browsers. */
+    compile?: boolean
+  };
+}
+
+export const buildPresets = new Map<string, ProjectBuildOptions>([
+  ['es5-bundled', {
+    name: 'es5-bundled',
+    js: {minify: true, compile: true},
+    css: {minify: true},
+    html: {minify: true},
+    bundle: true,
+    addServiceWorker: true,
+    addPushManifest: true,
+    insertPrefetchLinks: true,
+  }],
+  ['es6-bundled', {
+    name: 'es6-bundled',
+    js: {minify: true, compile: false},
+    css: {minify: true},
+    html: {minify: true},
+    bundle: true,
+    addServiceWorker: true,
+    addPushManifest: true,
+    insertPrefetchLinks: true,
+  }],
+  ['es6-unbundled', {
+    name: 'es6-unbundled',
+    js: {minify: true, compile: false},
+    css: {minify: true},
+    html: {minify: true},
+    bundle: false,
+    addServiceWorker: true,
+    addPushManifest: true,
+    insertPrefetchLinks: true,
+  }],
+]);
+
+export function isValidPreset(presetName: string) {
+  return buildPresets.has(presetName);
+}
+
+/**
+ * Apply a build preset (if a valid one exists on the config object) by
+ * deep merging the given config with the preset values.
+ */
+export function applyBuildPreset(config: ProjectBuildOptions) {
+  const presetName = config.preset;
+  if (!presetName || !isValidPreset(presetName)) {
+    return config;
+  }
+
+  const presetConfig = buildPresets.get(presetName);
+  const mergedConfig = Object.assign({}, presetConfig, config);
+  // Object.assign is shallow, so we need to make sure we properly merge these
+  // deep options as well.
+  // NOTE(fks) 05-05-2017: While a little annoying, we use multiple
+  // Object.assign() calls here so that we do not filter-out additional
+  // user-defined build options at the config level.
+  mergedConfig.js = Object.assign({}, presetConfig.js, config.js);
+  mergedConfig.css = Object.assign({}, presetConfig.css, config.css);
+  mergedConfig.html = Object.assign({}, presetConfig.html, config.html);
+  return mergedConfig;
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,10 @@ import * as fs from 'fs';
 import * as jsonschema from 'jsonschema';
 import * as path from 'path';
 import * as logging from 'plylog';
-
+import {applyBuildPreset, isValidPreset, ProjectBuildOptions} from './builds';
 import minimatchAll = require('minimatch-all');
+
+export {ProjectBuildOptions} from './builds';
 
 const logger = logging.getLogger('polymer-project-config');
 
@@ -67,89 +69,6 @@ function fixDeprecatedOptions(options: any): ProjectOptions {
         options.extraDependencies || options.includeDependencies;
   }
   return options;
-}
-
-export interface ProjectBuildOptions {
-  /**
-   * The name of this build, used to determine the output directory name.
-   */
-  name?: string;
-
-  /**
-   * Generate a service worker for your application to cache all files and
-   * assets on the client.
-   *
-   * Polymer CLI will generate a service worker for your build using the
-   * [sw-precache library](https://github.com/GoogleChrome/sw-precache). To
-   * customize your service worker, create a sw-precache-config.js file in your
-   * project directory that exports your configuration. See the [sw-precache
-   * README](https://github.com/GoogleChrome/sw-precache) for a list of all
-   * supported options.
-   *
-   * Note that the sw-precache library uses a cache-first strategy for maximum
-   * speed and makes some other assumptions about how your service worker should
-   * behave. Read the "Considerations" section of the sw-precache README to make
-   * sure that this is suitable for your application.
-   */
-  addServiceWorker?: boolean;
-
-  /**
-   * If `true`, generate an [HTTP/2 Push
-   * Manifest](https://github.com/GoogleChrome/http2-push-manifest) for your
-   * application.
-   */
-  addPushManifest?: boolean;
-
-  /**
-   * A config file that's passed to the [sw-precache
-   * library](https://github.com/GoogleChrome/sw-precache). See [its
-   * README](https://github.com/GoogleChrome/sw-precache) for details of the
-   * format of this file.
-   *
-   * Ignored if `addServiceWorker` is not `true`.
-   *
-   * Defaults to `"sw-precache-config.js`.
-   */
-  swPrecacheConfig?: string;
-
-  /**
-   * Insert prefetch link elements into your fragments so that all dependencies
-   * are prefetched immediately. Add dependency prefetching by inserting `<link
-   * rel="prefetch">` tags into entrypoint and `<link rel="import">` tags into
-   * fragments and shell for all dependencies.
-   */
-  insertPrefetchLinks?: boolean;
-
-  /**
-   * By default, fragments are unbundled. This is optimal for HTTP/2-compatible
-   * servers and clients.
-   *
-   * If the --bundle flag is supplied, all fragments are bundled together to
-   * reduce the number of file requests. This is optimal for sending to clients
-   * or serving from servers that are not HTTP/2 compatible.
-   */
-  bundle?: boolean;
-
-  /** Options for processing HTML. */
-  html?: {
-    /** Minify HTMl by removing comments and whitespace. */
-    minify?: boolean
-  };
-
-  /** Options for processing CSS. */
-  css?: {
-    /** Minify inlined and external CSS. */
-    minify?: boolean
-  };
-
-  /** Options for processing JavaScript. */
-  js?: {
-    /** Minify inlined and external JavaScript. */
-    minify?: boolean,
-
-    /** Use babel to compile all ES6 JS down to ES5 for older browsers. */
-    compile?: boolean
-  };
 }
 
 export interface LintOptions {
@@ -354,6 +273,9 @@ export class ProjectConfig {
      */
     if (options.builds) {
       this.builds = options.builds;
+      if (Array.isArray(this.builds)) {
+        this.builds = this.builds.map(applyBuildPreset);
+      }
     }
   }
 
@@ -419,6 +341,11 @@ export class ProjectConfig {
         const buildNames = new Set<string>();
         for (const build of this.builds) {
           const buildName = build.name;
+          const buildPreset = build.preset;
+          console.assert(
+              !buildPreset || isValidPreset(buildPreset),
+              `${validateErrorPrefix}: "${buildPreset}" is not a valid `
+              + ` "builds" preset.`);
           console.assert(
               buildName,
               `${validateErrorPrefix}: all "builds" require ` +

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import * as logging from 'plylog';
 import {applyBuildPreset, isValidPreset, ProjectBuildOptions} from './builds';
 import minimatchAll = require('minimatch-all');
 
-export {ProjectBuildOptions} from './builds';
+export {ProjectBuildOptions, applyBuildPreset} from './builds';
 
 const logger = logging.getLogger('polymer-project-config');
 

--- a/test/builds_test.js
+++ b/test/builds_test.js
@@ -1,0 +1,145 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+'use strict';
+const assert = require('chai').assert;
+const path = require('path');
+const {applyBuildPreset, isValidPreset} = require('../lib/builds');
+
+
+suite('builds', () => {
+
+  suite('isValidPreset()', () => {
+
+    test('returns true for valid presets', () => {
+      assert.equal(isValidPreset('es5-bundled'), true);
+      assert.equal(isValidPreset('es6-bundled'), true);
+      assert.equal(isValidPreset('es6-unbundled'), true);
+    });
+
+    test('returns false for a selection of invalid presets', () => {
+      assert.equal(isValidPreset('es5-unbundled'), false);
+      assert.equal(isValidPreset('es5'), false);
+      assert.equal(isValidPreset('es6'), false);
+      assert.equal(isValidPreset('js-compile'), false);
+      assert.equal(isValidPreset(''), false);
+      assert.equal(isValidPreset(null), false);
+      assert.equal(isValidPreset(undefined), false);
+      assert.equal(isValidPreset(0), false);
+      assert.equal(isValidPreset(1), false);
+    });
+
+  });
+
+  suite('applyBuildPreset()', () => {
+
+    test('applies es5-bundled preset', () => {
+      const givenBuildConfig = {
+        preset: 'es5-bundled'
+      };
+      const expectedBuildConfig = {
+        name: 'es5-bundled',
+        preset: 'es5-bundled',
+        js: {minify: true, compile: true},
+        css: {minify: true},
+        html: {minify: true},
+        bundle: true,
+        addServiceWorker: true,
+        addPushManifest: true,
+        insertPrefetchLinks: true,
+      };
+      assert.deepEqual(applyBuildPreset(givenBuildConfig), expectedBuildConfig);
+    });
+
+    test('applies es6-bundled preset', () => {
+      const givenBuildConfig = {
+        preset: 'es6-bundled'
+      };
+      const expectedBuildConfig = {
+        name: 'es6-bundled',
+        preset: 'es6-bundled',
+        js: {minify: true, compile: false},
+        css: {minify: true},
+        html: {minify: true},
+        bundle: true,
+        addServiceWorker: true,
+        addPushManifest: true,
+        insertPrefetchLinks: true,
+      };
+      assert.deepEqual(applyBuildPreset(givenBuildConfig), expectedBuildConfig);
+    });
+
+    test('applies es6-unbundled preset', () => {
+      const givenBuildConfig = {
+        preset: 'es6-unbundled'
+      };
+      const expectedBuildConfig = {
+        name: 'es6-unbundled',
+        preset: 'es6-unbundled',
+        js: {minify: true, compile: false},
+        css: {minify: true},
+        html: {minify: true},
+        bundle: false,
+        addServiceWorker: true,
+        addPushManifest: true,
+        insertPrefetchLinks: true,
+      };
+      assert.deepEqual(applyBuildPreset(givenBuildConfig), expectedBuildConfig);
+    });
+
+    test('applies provided config options as overrides to preset', () => {
+      const givenBuildConfig = {
+        preset: 'es5-bundled',
+        name: 'name-override',
+        js: {minify: false, compile: false},
+        css: {minify: false},
+        html: {minify: false},
+        bundle: false,
+        addServiceWorker: false,
+        addPushManifest: false,
+        insertPrefetchLinks: false,
+      };
+      const expectedBuildConfig = {
+        preset: 'es5-bundled',
+        name: 'name-override',
+        js: {minify: false, compile: false},
+        css: {minify: false},
+        html: {minify: false},
+        bundle: false,
+        addServiceWorker: false,
+        addPushManifest: false,
+        insertPrefetchLinks: false,
+      };
+      assert.deepEqual(applyBuildPreset(givenBuildConfig), expectedBuildConfig);
+    });
+
+    test('returns the same config if no preset is provided', () => {
+      const givenBuildConfig = {
+        name: 'no-preset',
+        js: {minify: true, compile: false},
+        css: {minify: true},
+        html: {minify: true},
+      };
+      assert.deepEqual(applyBuildPreset(givenBuildConfig), givenBuildConfig);
+    });
+
+    test('returns the same config if preset is provided but not found', () => {
+      const givenBuildConfig = {
+        preset: 'not-a-real-preset-name',
+        js: {minify: false, compile: true},
+        css: {minify: true},
+        html: {minify: true},
+      };
+      assert.deepEqual(applyBuildPreset(givenBuildConfig), givenBuildConfig);
+    });
+
+  });
+
+});

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -424,7 +424,7 @@ suite('Project Config', () => {
             insertPrefetchLinks: true,
           }
         });
-        assert.throws(() => config.validate(), /AssertionError: Polymer Config Error: "builds" \(\[object Object\]\) expected an array of build configurations\./);
+        assert.throws(() => config.validate(), 'AssertionError: Polymer Config Error: "builds" ([object Object]) expected an array of build configurations.');
       });
 
       test('throws an exception when builds array contains duplicate names', () => {
@@ -441,7 +441,7 @@ suite('Project Config', () => {
             }
           ]
         });
-        assert.throws(() => config.validate(), /AssertionError: Polymer Config Error: "builds" duplicate build name "bundled" found. Build names must be unique\./);
+        assert.throws(() => config.validate(), 'AssertionError: Polymer Config Error: "builds" duplicate build name "bundled" found. Build names must be unique.');
       });
 
       test('throws an exception when builds array contains an unnamed build', () => {
@@ -457,7 +457,22 @@ suite('Project Config', () => {
             }
           ]
         });
-        assert.throws(() => config.validate(), /AssertionError: Polymer Config Error: all "builds" require a "name" property when there are multiple builds defined\./);
+        assert.throws(() => config.validate(), 'AssertionError: Polymer Config Error: all "builds" require a "name" property when there are multiple builds defined.');
+      });
+
+      test('throws an exception when builds array contains an invalid preset', () => {
+        const absoluteRoot = process.cwd();
+        const config = new ProjectConfig({
+          builds: [
+            {
+              preset: 'not-a-real-preset',
+            },
+            {
+              bundle: true,
+            }
+          ]
+        });
+        assert.throws(() => config.validate(), 'AssertionError: Polymer Config Error: "not-a-real-preset" is not a valid  "builds" preset.');
       });
 
     });

--- a/test/polymer-invalid-syntax.json
+++ b/test/polymer-invalid-syntax.json
@@ -1,6 +1,6 @@
 {
   "entrypoint": "foo.html",
   "fragments": [
-    "bar.html",
+    "this-line-should-not-have-a-comma.html",
   ]
 }


### PR DESCRIPTION
- Add support for build presets. Build configurations now inherit from supported presets by name.
- See https://github.com/Polymer/polymer-cli/issues/714 for overview.
- (Ugh, travis is still testing Node v4 & v5.) Updating travis support in this PR to save the back-and-forth.
- [X] Changelog updated
