### PR TITLE
Add build options for differential serving.

### DIFF
--- a/src/builds.ts
+++ b/src/builds.ts
@@ -98,6 +98,30 @@ export interface ProjectBuildOptions {
     /** Use babel to compile all ES6 JS down to ES5 for older browsers. */
     compile?: boolean
   };
+
+  /**
+   * Browser capabilities required for serving this build. Used by servers that
+   * support differential serving to decide which build to serve to a given
+   * user agent.
+   *
+   * Values include `es2015` and `push`. See canonical list at:
+   * https://github.com/Polymer/prpl-server-node/blob/master/src/capabilities.ts
+   */
+  capabilities?: string[];
+
+  /**
+   * Transform resource references to facilitate serving this build from a
+   * non-root path. Useful for differential serving, where static resources
+   * for each build is served from a sub-directory.
+   *
+   * - Update the entrypoint's <base> tag, if found.
+   * - Prefix Service Worker pre-cached resources.
+   * - Prefix Push Manifest resources.
+   *
+   * If `true`, uses the build `name`, otherwise uses the given string.
+   * Leading/trailing slashes are optional.
+   */
+  base?: true|string;
 }
 
 export const buildPresets = new Map<string, ProjectBuildOptions>([

--- a/src/builds.ts
+++ b/src/builds.ts
@@ -99,7 +99,7 @@ export interface ProjectBuildOptions {
     compile?: boolean
   };
 
-  /** Options for serving this build. */
+  /** Options related to serving this build. */
   serving?: {
     /**
      * Capabilities required for a browser to consume this build. Values
@@ -114,8 +114,8 @@ export interface ProjectBuildOptions {
     browserCapabilities?: string[];
 
     /**
-     * Apply transformations to support serving this build from a non-root
-     * path, such as when doing differential serving of builds based on user
+     * Apply transformations during build to support serving this build from a
+     * non-root path, such as when doing differential serving based on user
      * agent. This works well in conjunction with the convention of using
      * relative URLs for static resources and absolute URLs for application
      * routes.

--- a/src/builds.ts
+++ b/src/builds.ts
@@ -99,39 +99,35 @@ export interface ProjectBuildOptions {
     compile?: boolean
   };
 
-  /** Options relating to the browser that consumes this build. */
-  client?: {
+  /** Options for serving this build. */
+  serving?: {
     /**
-     * Capabilities required for serving this build. Used by servers that
-     * support differential serving to decide which build to serve to a given
-     * user agent.
-     *
-     * Values include `es2015` and `push`. See canonical list at:
+     * Capabilities required for a browser to consume this build. Values
+     * include `es2015` and `push`. See canonical list at:
      * https://github.com/Polymer/prpl-server-node/blob/master/src/capabilities.ts
+     *
+     * This field is purely a hint to servers reading this configuration, and
+     * does not affect the build process. A server supporting differential
+     * serving (e.g. prpl-server) can use this field to help decide which build
+     * to serve to a given user agent.
      */
-    capabilities?: string[];
-  };
+    browserCapabilities?: string[];
 
-  /**
-   * Options for transforming resource references to facilitate serving this
-   * build from a non-root path. Useful for differential serving, where static
-   * resources for each build are served from sub-directories.
-   */
-  rewritePaths?: {
     /**
-     * Use this prefix for rewriting. Defaults to the build's `name`.
+     * Apply transformations to support serving this build from a non-root
+     * path, such as when doing differential serving of builds based on user
+     * agent. This works well in conjunction with the convention of using
+     * relative URLs for static resources and absolute URLs for application
+     * routes.
+     *
+     * - Find and update the entrypoint's `<base>` tag.
+     * - Prefix Service Worker pre-cached resources.
+     * - Prefix Push Manifest resources.
+     *
+     * If `true`, use the build `name`. If a `string`, use that value.
      * Leading/trailing slashes are optional.
      */
-    prefix?: string,
-
-    /** Update the entrypoint's `<base>` tag, if found. */
-    baseTag?: boolean,
-
-    /** Prefix Service Worker pre-cached resources. */
-    serviceWorker?: boolean,
-
-    /* Prefix Push Manifest resources. */
-    pushManifest?: boolean
+    basePath?: boolean | string;
   };
 }
 
@@ -194,4 +190,3 @@ export function applyBuildPreset(config: ProjectBuildOptions) {
   mergedConfig.html = Object.assign({}, presetConfig.html, config.html);
   return mergedConfig;
 }
-

--- a/src/builds.ts
+++ b/src/builds.ts
@@ -19,8 +19,7 @@ export interface ProjectBuildOptions {
   name?: string;
 
   /**
-   * A build preset for this build. A build can inherit some base configuration
-   * from a named preset.
+   * A build preset for this build. A build can inherit some base configuration from a named preset.
    */
   preset?: string;
 
@@ -137,42 +136,36 @@ export interface ProjectBuildOptions {
 }
 
 export const buildPresets = new Map<string, ProjectBuildOptions>([
-  [
-    'es5-bundled', {
-      name : 'es5-bundled',
-      js : {minify : true, compile : true},
-      css : {minify : true},
-      html : {minify : true},
-      bundle : true,
-      addServiceWorker : true,
-      addPushManifest : true,
-      insertPrefetchLinks : true,
-    }
-  ],
-  [
-    'es6-bundled', {
-      name : 'es6-bundled',
-      js : {minify : true, compile : false},
-      css : {minify : true},
-      html : {minify : true},
-      bundle : true,
-      addServiceWorker : true,
-      addPushManifest : true,
-      insertPrefetchLinks : true,
-    }
-  ],
-  [
-    'es6-unbundled', {
-      name : 'es6-unbundled',
-      js : {minify : true, compile : false},
-      css : {minify : true},
-      html : {minify : true},
-      bundle : false,
-      addServiceWorker : true,
-      addPushManifest : true,
-      insertPrefetchLinks : true,
-    }
-  ],
+  ['es5-bundled', {
+    name: 'es5-bundled',
+    js: {minify: true, compile: true},
+    css: {minify: true},
+    html: {minify: true},
+    bundle: true,
+    addServiceWorker: true,
+    addPushManifest: true,
+    insertPrefetchLinks: true,
+  }],
+  ['es6-bundled', {
+    name: 'es6-bundled',
+    js: {minify: true, compile: false},
+    css: {minify: true},
+    html: {minify: true},
+    bundle: true,
+    addServiceWorker: true,
+    addPushManifest: true,
+    insertPrefetchLinks: true,
+  }],
+  ['es6-unbundled', {
+    name: 'es6-unbundled',
+    js: {minify: true, compile: false},
+    css: {minify: true},
+    html: {minify: true},
+    bundle: false,
+    addServiceWorker: true,
+    addPushManifest: true,
+    insertPrefetchLinks: true,
+  }],
 ]);
 
 export function isValidPreset(presetName: string) {
@@ -201,3 +194,4 @@ export function applyBuildPreset(config: ProjectBuildOptions) {
   mergedConfig.html = Object.assign({}, presetConfig.html, config.html);
   return mergedConfig;
 }
+

--- a/src/builds.ts
+++ b/src/builds.ts
@@ -19,7 +19,8 @@ export interface ProjectBuildOptions {
   name?: string;
 
   /**
-   * A build preset for this build. A build can inherit some base configuration from a named preset.
+   * A build preset for this build. A build can inherit some base configuration
+   * from a named preset.
    */
   preset?: string;
 
@@ -99,62 +100,79 @@ export interface ProjectBuildOptions {
     compile?: boolean
   };
 
-  /**
-   * Browser capabilities required for serving this build. Used by servers that
-   * support differential serving to decide which build to serve to a given
-   * user agent.
-   *
-   * Values include `es2015` and `push`. See canonical list at:
-   * https://github.com/Polymer/prpl-server-node/blob/master/src/capabilities.ts
-   */
-  capabilities?: string[];
+  /** Options relating to the browser that consumes this build. */
+  client?: {
+    /**
+     * Capabilities required for serving this build. Used by servers that
+     * support differential serving to decide which build to serve to a given
+     * user agent.
+     *
+     * Values include `es2015` and `push`. See canonical list at:
+     * https://github.com/Polymer/prpl-server-node/blob/master/src/capabilities.ts
+     */
+    capabilities?: string[];
+  };
 
   /**
-   * Transform resource references to facilitate serving this build from a
-   * non-root path. Useful for differential serving, where static resources
-   * for each build is served from a sub-directory.
-   *
-   * - Update the entrypoint's <base> tag, if found.
-   * - Prefix Service Worker pre-cached resources.
-   * - Prefix Push Manifest resources.
-   *
-   * If `true`, uses the build `name`, otherwise uses the given string.
-   * Leading/trailing slashes are optional.
+   * Options for transforming resource references to facilitate serving this
+   * build from a non-root path. Useful for differential serving, where static
+   * resources for each build are served from sub-directories.
    */
-  base?: true|string;
+  rewritePaths?: {
+    /**
+     * Use this prefix for rewriting. Defaults to the build's `name`.
+     * Leading/trailing slashes are optional.
+     */
+    prefix?: string,
+
+    /** Update the entrypoint's `<base>` tag, if found. */
+    baseTag?: boolean,
+
+    /** Prefix Service Worker pre-cached resources. */
+    serviceWorker?: boolean,
+
+    /* Prefix Push Manifest resources. */
+    pushManifest?: boolean
+  };
 }
 
 export const buildPresets = new Map<string, ProjectBuildOptions>([
-  ['es5-bundled', {
-    name: 'es5-bundled',
-    js: {minify: true, compile: true},
-    css: {minify: true},
-    html: {minify: true},
-    bundle: true,
-    addServiceWorker: true,
-    addPushManifest: true,
-    insertPrefetchLinks: true,
-  }],
-  ['es6-bundled', {
-    name: 'es6-bundled',
-    js: {minify: true, compile: false},
-    css: {minify: true},
-    html: {minify: true},
-    bundle: true,
-    addServiceWorker: true,
-    addPushManifest: true,
-    insertPrefetchLinks: true,
-  }],
-  ['es6-unbundled', {
-    name: 'es6-unbundled',
-    js: {minify: true, compile: false},
-    css: {minify: true},
-    html: {minify: true},
-    bundle: false,
-    addServiceWorker: true,
-    addPushManifest: true,
-    insertPrefetchLinks: true,
-  }],
+  [
+    'es5-bundled', {
+      name : 'es5-bundled',
+      js : {minify : true, compile : true},
+      css : {minify : true},
+      html : {minify : true},
+      bundle : true,
+      addServiceWorker : true,
+      addPushManifest : true,
+      insertPrefetchLinks : true,
+    }
+  ],
+  [
+    'es6-bundled', {
+      name : 'es6-bundled',
+      js : {minify : true, compile : false},
+      css : {minify : true},
+      html : {minify : true},
+      bundle : true,
+      addServiceWorker : true,
+      addPushManifest : true,
+      insertPrefetchLinks : true,
+    }
+  ],
+  [
+    'es6-unbundled', {
+      name : 'es6-unbundled',
+      js : {minify : true, compile : false},
+      css : {minify : true},
+      html : {minify : true},
+      bundle : false,
+      addServiceWorker : true,
+      addPushManifest : true,
+      insertPrefetchLinks : true,
+    }
+  ],
 ]);
 
 export function isValidPreset(presetName: string) {
@@ -183,4 +201,3 @@ export function applyBuildPreset(config: ProjectBuildOptions) {
   mergedConfig.html = Object.assign({}, presetConfig.html, config.html);
   return mergedConfig;
 }
-

--- a/src/builds.ts
+++ b/src/builds.ts
@@ -99,36 +99,33 @@ export interface ProjectBuildOptions {
     compile?: boolean
   };
 
-  /** Options related to serving this build. */
-  serving?: {
-    /**
-     * Capabilities required for a browser to consume this build. Values
-     * include `es2015` and `push`. See canonical list at:
-     * https://github.com/Polymer/prpl-server-node/blob/master/src/capabilities.ts
-     *
-     * This field is purely a hint to servers reading this configuration, and
-     * does not affect the build process. A server supporting differential
-     * serving (e.g. prpl-server) can use this field to help decide which build
-     * to serve to a given user agent.
-     */
-    browserCapabilities?: string[];
+  /**
+   * Capabilities required for a browser to consume this build. Values include
+   * `es2015` and `push`. See canonical list at:
+   * https://github.com/Polymer/prpl-server-node/blob/master/src/capabilities.ts
+   *
+   * This field is purely a hint to servers reading this configuration, and
+   * does not affect the build process. A server supporting differential
+   * serving (e.g. prpl-server) can use this field to help decide which build
+   * to serve to a given user agent.
+   */
+  browserCapabilities?: string[];
 
-    /**
-     * Apply transformations during build to support serving this build from a
-     * non-root path, such as when doing differential serving based on user
-     * agent. This works well in conjunction with the convention of using
-     * relative URLs for static resources and absolute URLs for application
-     * routes.
-     *
-     * - Find and update the entrypoint's `<base>` tag.
-     * - Prefix Service Worker pre-cached resources.
-     * - Prefix Push Manifest resources.
-     *
-     * If `true`, use the build `name`. If a `string`, use that value.
-     * Leading/trailing slashes are optional.
-     */
-    basePath?: boolean | string;
-  };
+  /**
+   * Apply transformations during build to support serving this build from a
+   * non-root path, such as when doing differential serving based on user
+   * agent. This works well in conjunction with the convention of using
+   * relative URLs for static resources and absolute URLs for application
+   * routes.
+   *
+   * - Find and update the entrypoint's `<base>` tag.
+   * - Prefix Service Worker pre-cached resources.
+   * - Prefix Push Manifest resources.
+   *
+   * If `true`, use the build `name`. If a `string`, use that value.
+   * Leading/trailing slashes are optional.
+   */
+  basePath?: boolean | string;
 }
 
 export const buildPresets = new Map<string, ProjectBuildOptions>([
@@ -190,3 +187,4 @@ export function applyBuildPreset(config: ProjectBuildOptions) {
   mergedConfig.html = Object.assign({}, presetConfig.html, config.html);
   return mergedConfig;
 }
+


### PR DESCRIPTION
Some new build config options for the features needed to generate builds suitable for differential serving.

Not totally confident about the name/organization, so suggestions welcome. E.g. should each of the `base` transformations be split out? Also the Service Worker asset list transformation could be done by setting the`replacePrefix` option of `sw-precache`, but it seems like a pain to have to construct a full config file just for this option.