### PR TITLE
Add ProjectConfig.toJSON method

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,12 @@
+BasedOnStyle: Google
+AlignAfterOpenBracket: AlwaysBreak
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+BinPackArguments: false
+# This breaks async functions sometimes, see
+#     https://github.com/Polymer/polymer-analyzer/pull/393
+# BinPackParameters: false

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "homepage": "https://github.com/Polymer/polymer-project-config#readme",
   "scripts": {
     "build": "tsc && typescript-json-schema src/index.ts ProjectOptions --ignoreErrors -o lib/schema.json",
-    "test": "npm run build && mocha --ui tdd"
+    "test": "npm run build && mocha --ui tdd",
+    "format": "find src test \\( -iname '*.ts' -o -iname '*.js' \\) | xargs clang-format --style=file -i"
   },
   "dependencies": {
     "@types/node": "^6.0.41",

--- a/src/builds.ts
+++ b/src/builds.ts
@@ -191,7 +191,7 @@ export function applyBuildPreset(config: ProjectBuildOptions) {
     return config;
   }
 
-  const presetConfig = buildPresets.get(presetName);
+  const presetConfig = buildPresets.get(presetName) || {};
   const mergedConfig = Object.assign({}, presetConfig, config);
   // Object.assign is shallow, so we need to make sure we properly merge these
   // deep options as well.

--- a/src/builds.ts
+++ b/src/builds.ts
@@ -126,12 +126,13 @@ export interface ProjectBuildOptions {
    * If `true`, use the build `name`. If a `string`, use that value.
    * Leading/trailing slashes are optional.
    */
-  basePath?: boolean | string;
+  basePath?: boolean|string;
 }
 
 export const buildPresets = new Map<string, ProjectBuildOptions>([
   [
-    'es5-bundled', {
+    'es5-bundled',
+    {
       name: 'es5-bundled',
       js: {minify: true, compile: true},
       css: {minify: true},
@@ -145,7 +146,8 @@ export const buildPresets = new Map<string, ProjectBuildOptions>([
     }
   ],
   [
-    'es6-bundled', {
+    'es6-bundled',
+    {
       name: 'es6-bundled',
       browserCapabilities: ['es2015'],
       js: {minify: true, compile: false},
@@ -160,7 +162,8 @@ export const buildPresets = new Map<string, ProjectBuildOptions>([
     }
   ],
   [
-    'es6-unbundled', {
+    'es6-unbundled',
+    {
       name: 'es6-unbundled',
       browserCapabilities: ['es2015', 'push'],
       js: {minify: true, compile: false},

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ export class ProjectConfig {
    *
    * TODO: make this method and the one below async.
    */
-  static loadOptionsFromFile(filepath: string): ProjectOptions {
+  static loadOptionsFromFile(filepath: string): ProjectOptions|null {
     try {
       const configContent = fs.readFileSync(filepath, 'utf-8');
       const contents = JSON.parse(configContent);
@@ -180,7 +180,7 @@ export class ProjectConfig {
    * Given an absolute file path to a polymer.json-like ProjectOptions object,
    * return a new ProjectConfig instance created with those options.
    */
-  static loadConfigFromFile(filepath: string): ProjectConfig {
+  static loadConfigFromFile(filepath: string): ProjectConfig|null {
     let configParsed = ProjectConfig.loadOptionsFromFile(filepath);
     if (!configParsed) {
       return null;
@@ -351,10 +351,10 @@ export class ProjectConfig {
               `${validateErrorPrefix}: all "builds" require ` +
                   `a "name" property when there are multiple builds defined.`);
           console.assert(
-              !buildNames.has(buildName),
+              !buildNames.has(buildName!),
               `${validateErrorPrefix}: "builds" duplicate build name ` +
                   `"${buildName}" found. Build names must be unique.`);
-          buildNames.add(buildName);
+          buildNames.add(buildName!);
         }
       }
     }
@@ -386,7 +386,7 @@ export class ProjectConfig {
 // interface for runtime validation. See the build script in package.json for
 // more info.
 const getSchema: () => jsonschema.Schema = (() => {
-  let schema: jsonschema.Schema|undefined = undefined;
+  let schema: jsonschema.Schema;
 
   return () => {
     if (schema === undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -344,8 +344,8 @@ export class ProjectConfig {
           const buildPreset = build.preset;
           console.assert(
               !buildPreset || isValidPreset(buildPreset),
-              `${validateErrorPrefix}: "${buildPreset}" is not a valid `
-              + ` "builds" preset.`);
+              `${validateErrorPrefix}: "${buildPreset}" is not a valid ` +
+                  ` "builds" preset.`);
           console.assert(
               buildName,
               `${validateErrorPrefix}: all "builds" require ` +

--- a/src/index.ts
+++ b/src/index.ts
@@ -361,6 +361,25 @@ export class ProjectConfig {
 
     return true;
   }
+
+  /**
+   * Generate a JSON string serialization of this configuration. File paths
+   * will be relative to root.
+   */
+  toJSON(): string {
+    const relative = (p: string | null | undefined) =>
+        p ? path.relative(this.root, p) : undefined;
+    return JSON.stringify({
+      root: this.root,
+      entrypoint: relative(this.entrypoint),
+      shell: relative(this.shell),
+      fragments: (this.fragments || []).map(relative),
+      sources: (this.sources || []).map(relative),
+      extraDependencies: (this.extraDependencies || []).map(relative),
+      builds: this.builds,
+      lint: this.lint,
+    });
+  }
 }
 
 // Gets the json schema for polymer.json, generated from the typescript

--- a/test/builds_test.js
+++ b/test/builds_test.js
@@ -1,18 +1,18 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
 const assert = require('chai').assert;
 const path = require('path');
 const {applyBuildPreset, isValidPreset} = require('../lib/builds');
-
 
 suite('builds', () => {
 
@@ -41,9 +41,7 @@ suite('builds', () => {
   suite('applyBuildPreset()', () => {
 
     test('applies es5-bundled preset', () => {
-      const givenBuildConfig = {
-        preset: 'es5-bundled'
-      };
+      const givenBuildConfig = {preset: 'es5-bundled'};
       const expectedBuildConfig = {
         name: 'es5-bundled',
         preset: 'es5-bundled',
@@ -59,9 +57,7 @@ suite('builds', () => {
     });
 
     test('applies es6-bundled preset', () => {
-      const givenBuildConfig = {
-        preset: 'es6-bundled'
-      };
+      const givenBuildConfig = {preset: 'es6-bundled'};
       const expectedBuildConfig = {
         name: 'es6-bundled',
         preset: 'es6-bundled',
@@ -78,9 +74,7 @@ suite('builds', () => {
     });
 
     test('applies es6-unbundled preset', () => {
-      const givenBuildConfig = {
-        preset: 'es6-unbundled'
-      };
+      const givenBuildConfig = {preset: 'es6-unbundled'};
       const expectedBuildConfig = {
         name: 'es6-unbundled',
         preset: 'es6-unbundled',

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -590,4 +590,63 @@ suite('Project Config', () => {
 
   });
 
+  suite('toJSON()', () => {
+    test('with minimal config', () => {
+      const config = ProjectConfig.loadConfigFromFile(
+          path.join(__dirname, 'polymer-minimal.json'));
+      assert.deepEqual(JSON.parse(config.toJSON()), {
+        root: process.cwd(),
+        entrypoint: 'index.html',
+        fragments: [],
+        sources: [
+          'src/**/*',
+          'index.html',
+        ],
+        extraDependencies: [],
+      });
+    });
+
+    test('with full config', () => {
+      const config = ProjectConfig.loadConfigFromFile(
+          path.join(__dirname, 'polymer-full.json'));
+      assert.deepEqual(JSON.parse(config.toJSON()), {
+        root: path.resolve('public'),
+        entrypoint: 'entrypoint.html',
+        shell: 'shell.html',
+        fragments: ['fragment.html'],
+        sources: [
+          'src/**/*',
+          'images/**/*',
+          'entrypoint.html',
+          'shell.html',
+          'fragment.html',
+        ],
+        extraDependencies: ['extra.html'],
+        builds: [
+          {
+            preset: 'es6-bundled',
+            name: 'es6-bundled',
+            addServiceWorker: true,
+            addPushManifest: true,
+            insertPrefetchLinks: false,
+            bundle: true,
+            html: {minify: true},
+            css: {minify: true},
+            js: {minify: true, compile: false},
+            browserCapabilities: ['es2015']
+          },
+          {
+            name: 'my-build',
+            swPrecacheConfig: 'sw.conf',
+            browserCapabilities: ['es2015'],
+            basePath: true
+          },
+        ],
+        lint: {
+          rules: ['some-rule'],
+          ignoreWarnings: ['some-warning'],
+        }
+      });
+    });
+  });
 });

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -1,11 +1,12 @@
 /**
  * @license
  * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
- * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
- * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
- * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
- * Code distributed by Google as part of the polymer project is also
- * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
 'use strict';
@@ -38,33 +39,33 @@ suite('Project Config', () => {
         });
       });
 
-      test('sets root relative to current working directory when provided', () => {
-        const relativeRoot = 'public';
-        const absoluteRoot = path.resolve(relativeRoot);
-        const config = new ProjectConfig({root: relativeRoot});
-        config.validate();
+      test(
+          'sets root relative to current working directory when provided',
+          () => {
+            const relativeRoot = 'public';
+            const absoluteRoot = path.resolve(relativeRoot);
+            const config = new ProjectConfig({root: relativeRoot});
+            config.validate();
 
-        assert.deepEqual(config, {
-          root: absoluteRoot,
-          entrypoint: path.resolve(absoluteRoot, 'index.html'),
-          fragments: [],
-          allFragments: [path.resolve(absoluteRoot, 'index.html')],
-          extraDependencies: [],
-          sources: [
-            path.resolve(absoluteRoot, 'src/**/*'),
-            path.resolve(absoluteRoot, 'index.html'),
-          ],
-          lint: undefined,
-        });
-      });
+            assert.deepEqual(config, {
+              root: absoluteRoot,
+              entrypoint: path.resolve(absoluteRoot, 'index.html'),
+              fragments: [],
+              allFragments: [path.resolve(absoluteRoot, 'index.html')],
+              extraDependencies: [],
+              sources: [
+                path.resolve(absoluteRoot, 'src/**/*'),
+                path.resolve(absoluteRoot, 'index.html'),
+              ],
+              lint: undefined,
+            });
+          });
 
       test('sets entrypoint relative to root when provided', () => {
         const relativeRoot = 'public';
         const absoluteRoot = path.resolve(relativeRoot);
-        const config = new ProjectConfig({
-          root: relativeRoot,
-          entrypoint: 'foo.html'
-        });
+        const config =
+            new ProjectConfig({root: relativeRoot, entrypoint: 'foo.html'});
         config.validate();
 
         assert.deepEqual(config, {
@@ -82,9 +83,7 @@ suite('Project Config', () => {
       });
 
       test('sets shell relative to root when provided', () => {
-        const config = new ProjectConfig({
-          shell: 'foo.html'
-        });
+        const config = new ProjectConfig({shell: 'foo.html'});
         config.validate();
 
         assert.deepEqual(config, {
@@ -92,9 +91,7 @@ suite('Project Config', () => {
           entrypoint: path.resolve('index.html'),
           shell: path.resolve('foo.html'),
           fragments: [],
-          allFragments: [
-            path.resolve('foo.html')
-          ],
+          allFragments: [path.resolve('foo.html')],
           extraDependencies: [],
           sources: [
             path.resolve('src/**/*'),
@@ -106,9 +103,7 @@ suite('Project Config', () => {
       });
 
       test('sets fragments relative to root when provided', () => {
-        const config = new ProjectConfig({
-          fragments: ['foo.html', 'bar.html']
-        });
+        const config = new ProjectConfig({fragments: ['foo.html', 'bar.html']});
         config.validate();
 
         assert.deepEqual(config, {
@@ -136,10 +131,8 @@ suite('Project Config', () => {
       test('adds sources relative to root when provided', () => {
         const relativeRoot = 'public';
         const absoluteRoot = path.resolve(relativeRoot);
-        const config = new ProjectConfig({
-          root: relativeRoot,
-          sources: ['src/**/*', 'images/**/*']
-        });
+        const config = new ProjectConfig(
+            {root: relativeRoot, sources: ['src/**/*', 'images/**/*']});
         config.validate();
 
         assert.deepEqual(config, {
@@ -176,7 +169,9 @@ suite('Project Config', () => {
           allFragments: [path.resolve(absoluteRoot, 'index.html')],
           extraDependencies: [
             path.resolve(absoluteRoot, 'bower_components/**/*.js'),
-            '!' + path.resolve(absoluteRoot, 'bower_components/ignore-big-package'),
+            '!' +
+                path.resolve(
+                    absoluteRoot, 'bower_components/ignore-big-package'),
           ],
           sources: [
             path.resolve(absoluteRoot, 'src/**/*'),
@@ -186,78 +181,84 @@ suite('Project Config', () => {
         });
       });
 
-      test('sets allFragments to fragments & shell when both are provided', () => {
-        const config = new ProjectConfig({
-          fragments: ['foo.html', 'bar.html'],
-          shell: 'baz.html',
-        });
-        config.validate();
+      test(
+          'sets allFragments to fragments & shell when both are provided',
+          () => {
+            const config = new ProjectConfig({
+              fragments: ['foo.html', 'bar.html'],
+              shell: 'baz.html',
+            });
+            config.validate();
 
-        assert.deepEqual(config, {
-          root: process.cwd(),
-          entrypoint: path.resolve('index.html'),
-          shell: path.resolve('baz.html'),
-          fragments: [
-            path.resolve('foo.html'),
-            path.resolve('bar.html'),
-          ],
-          allFragments: [
-            path.resolve('baz.html'),
-            path.resolve('foo.html'),
-            path.resolve('bar.html'),
-          ],
-          extraDependencies: [],
-          sources: [
-            path.resolve('src/**/*'),
-            path.resolve('index.html'),
-            path.resolve('baz.html'),
-            path.resolve('foo.html'),
-            path.resolve('bar.html'),
-          ],
-          lint: undefined,
-        });
-      });
+            assert.deepEqual(config, {
+              root: process.cwd(),
+              entrypoint: path.resolve('index.html'),
+              shell: path.resolve('baz.html'),
+              fragments: [
+                path.resolve('foo.html'),
+                path.resolve('bar.html'),
+              ],
+              allFragments: [
+                path.resolve('baz.html'),
+                path.resolve('foo.html'),
+                path.resolve('bar.html'),
+              ],
+              extraDependencies: [],
+              sources: [
+                path.resolve('src/**/*'),
+                path.resolve('index.html'),
+                path.resolve('baz.html'),
+                path.resolve('foo.html'),
+                path.resolve('bar.html'),
+              ],
+              lint: undefined,
+            });
+          });
 
-      test('builds property is unset when `build` option is not provided', () => {
-        const absoluteRoot = process.cwd();
-        const config = new ProjectConfig();
-        config.validate();
+      test(
+          'builds property is unset when `build` option is not provided',
+          () => {
+            const absoluteRoot = process.cwd();
+            const config = new ProjectConfig();
+            config.validate();
 
-        assert.isUndefined(config.builds);
-      });
+            assert.isUndefined(config.builds);
+          });
 
-      test('sets builds property to an array when `build` option is an array', () => {
-        const absoluteRoot = process.cwd();
-        const config = new ProjectConfig({
-          builds: [
-            {
-              name: 'bundled',
-              bundle: true,
-              insertPrefetchLinks: true,
-            },
-            {
-              name: 'unbundled',
-              bundle: false,
-              insertPrefetchLinks: true,
-            }
-          ]
-        });
-        config.validate();
+      test(
+          'sets builds property to an array when `build` option is an array',
+          () => {
+            const absoluteRoot = process.cwd();
+            const config = new ProjectConfig({
+              builds: [
+                {
+                  name: 'bundled',
+                  bundle: true,
+                  insertPrefetchLinks: true,
+                },
+                {
+                  name: 'unbundled',
+                  bundle: false,
+                  insertPrefetchLinks: true,
+                }
+              ]
+            });
+            config.validate();
 
-        assert.property(config, 'builds');
-        assert.deepEqual(config.builds, [
-          {
-            name: 'bundled',
-            bundle: true,
-            insertPrefetchLinks: true,
-          },
-          {
-            name: 'unbundled',
-            bundle: false,
-            insertPrefetchLinks: true,
-          }
-        ]);
-      });
+            assert.property(config, 'builds');
+            assert.deepEqual(config.builds, [
+              {
+                name: 'bundled',
+                bundle: true,
+                insertPrefetchLinks: true,
+              },
+              {
+                name: 'unbundled',
+                bundle: false,
+                insertPrefetchLinks: true,
+              }
+            ]);
+          });
     });
 
     suite('isFragment()', () => {
@@ -274,11 +275,15 @@ suite('Project Config', () => {
         config.validate();
 
         assert.isTrue(config.isFragment(config.shell));
-        assert.isTrue(config.isFragment(path.resolve(absoluteRoot, 'bar.html')));
-        assert.isTrue(config.isFragment(path.resolve(absoluteRoot, 'baz.html')));
+        assert.isTrue(
+            config.isFragment(path.resolve(absoluteRoot, 'bar.html')));
+        assert.isTrue(
+            config.isFragment(path.resolve(absoluteRoot, 'baz.html')));
         assert.isFalse(config.isFragment(config.entrypoint));
-        assert.isFalse(config.isFragment(path.resolve(absoluteRoot, 'foo.html')));
-        assert.isFalse(config.isFragment(path.resolve(absoluteRoot, 'not-a-fragment.html')));
+        assert.isFalse(
+            config.isFragment(path.resolve(absoluteRoot, 'foo.html')));
+        assert.isFalse(config.isFragment(
+            path.resolve(absoluteRoot, 'not-a-fragment.html')));
       });
 
     });
@@ -301,29 +306,36 @@ suite('Project Config', () => {
         assert.isFalse(config.isShell(path.resolve(absoluteRoot, 'foo.html')));
         assert.isFalse(config.isShell(path.resolve(absoluteRoot, 'bar.html')));
         assert.isTrue(config.isShell(path.resolve(absoluteRoot, 'baz.html')));
-        assert.isFalse(config.isShell(path.resolve(absoluteRoot, 'not-a-fragment.html')));
+        assert.isFalse(
+            config.isShell(path.resolve(absoluteRoot, 'not-a-fragment.html')));
       });
 
     });
 
     suite('isSource()', () => {
 
-      test('matches source file paths and does not match other file paths', () => {
-        const relativeRoot = 'public';
-        const absoluteRoot = path.resolve(relativeRoot);
-        const config = new ProjectConfig({
-          root: relativeRoot,
-          entrypoint: 'foo.html',
-          fragments: ['bar.html'],
-          shell: 'baz.html',
-        });
-        assert.isTrue(config.isSource(config.entrypoint));
-        assert.isTrue(config.isSource(config.shell));
-        assert.isTrue(config.isSource(path.resolve(absoluteRoot, 'foo.html')));
-        assert.isTrue(config.isSource(path.resolve(absoluteRoot, 'bar.html')));
-        assert.isTrue(config.isSource(path.resolve(absoluteRoot, 'baz.html')));
-        assert.isFalse(config.isSource(path.resolve(absoluteRoot, 'not-a-fragment.html')));
-      });
+      test(
+          'matches source file paths and does not match other file paths',
+          () => {
+            const relativeRoot = 'public';
+            const absoluteRoot = path.resolve(relativeRoot);
+            const config = new ProjectConfig({
+              root: relativeRoot,
+              entrypoint: 'foo.html',
+              fragments: ['bar.html'],
+              shell: 'baz.html',
+            });
+            assert.isTrue(config.isSource(config.entrypoint));
+            assert.isTrue(config.isSource(config.shell));
+            assert.isTrue(
+                config.isSource(path.resolve(absoluteRoot, 'foo.html')));
+            assert.isTrue(
+                config.isSource(path.resolve(absoluteRoot, 'bar.html')));
+            assert.isTrue(
+                config.isSource(path.resolve(absoluteRoot, 'baz.html')));
+            assert.isFalse(config.isSource(
+                path.resolve(absoluteRoot, 'not-a-fragment.html')));
+          });
 
     });
 
@@ -375,7 +387,9 @@ suite('Project Config', () => {
           fragments: ['../bar.html'],
         });
 
-        assert.throws(() => config.validate(), /AssertionError: Polymer Config Error: a "fragments" path \(.*bar.html\) does not resolve within root \(.*public\)/);
+        assert.throws(
+            () => config.validate(),
+            /AssertionError: Polymer Config Error: a "fragments" path \(.*bar.html\) does not resolve within root \(.*public\)/);
       });
 
       test('throws an exception when entrypoint does not resolve within root', () => {
@@ -386,7 +400,9 @@ suite('Project Config', () => {
           entrypoint: '../bar.html',
         });
 
-        assert.throws(() => config.validate(), /AssertionError: Polymer Config Error: entrypoint \(.*bar.html\) does not resolve within root \(.*public\)/);
+        assert.throws(
+            () => config.validate(),
+            /AssertionError: Polymer Config Error: entrypoint \(.*bar.html\) does not resolve within root \(.*public\)/);
       });
 
       test('throws an exception when shell does not resolve within root', () => {
@@ -397,7 +413,9 @@ suite('Project Config', () => {
           shell: '/some/absolute/path/bar.html',
         });
 
-        assert.throws(() => config.validate(), /AssertionError: Polymer Config Error: shell \(.*bar.html\) does not resolve within root \(.*public\)/);
+        assert.throws(
+            () => config.validate(),
+            /AssertionError: Polymer Config Error: shell \(.*bar.html\) does not resolve within root \(.*public\)/);
       });
 
       test('returns true when a single, unnamed build is defined', () => {
@@ -424,7 +442,9 @@ suite('Project Config', () => {
             insertPrefetchLinks: true,
           }
         });
-        assert.throws(() => config.validate(), 'AssertionError: Polymer Config Error: "builds" ([object Object]) expected an array of build configurations.');
+        assert.throws(
+            () => config.validate(),
+            'AssertionError: Polymer Config Error: "builds" ([object Object]) expected an array of build configurations.');
       });
 
       test('throws an exception when builds array contains duplicate names', () => {
@@ -441,7 +461,9 @@ suite('Project Config', () => {
             }
           ]
         });
-        assert.throws(() => config.validate(), 'AssertionError: Polymer Config Error: "builds" duplicate build name "bundled" found. Build names must be unique.');
+        assert.throws(
+            () => config.validate(),
+            'AssertionError: Polymer Config Error: "builds" duplicate build name "bundled" found. Build names must be unique.');
       });
 
       test('throws an exception when builds array contains an unnamed build', () => {
@@ -457,7 +479,9 @@ suite('Project Config', () => {
             }
           ]
         });
-        assert.throws(() => config.validate(), 'AssertionError: Polymer Config Error: all "builds" require a "name" property when there are multiple builds defined.');
+        assert.throws(
+            () => config.validate(),
+            'AssertionError: Polymer Config Error: all "builds" require a "name" property when there are multiple builds defined.');
       });
 
       test('throws an exception when builds array contains an invalid preset', () => {
@@ -472,7 +496,9 @@ suite('Project Config', () => {
             }
           ]
         });
-        assert.throws(() => config.validate(), 'AssertionError: Polymer Config Error: "not-a-real-preset" is not a valid  "builds" preset.');
+        assert.throws(
+            () => config.validate(),
+            'AssertionError: Polymer Config Error: "not-a-real-preset" is not a valid  "builds" preset.');
       });
 
     });
@@ -497,7 +523,8 @@ suite('Project Config', () => {
     });
 
     test('reads options from config file', () => {
-      const options = ProjectConfig.loadOptionsFromFile(path.join(__dirname, 'polymer.json'));
+      const options = ProjectConfig.loadOptionsFromFile(
+          path.join(__dirname, 'polymer.json'));
       assert.deepEqual(options, {
         root: 'public',
         entrypoint: 'foo.html',
@@ -509,7 +536,7 @@ suite('Project Config', () => {
 
     test('reads options from a file with just {} in it', () => {
       const options = ProjectConfig.loadOptionsFromFile(
-        path.join(__dirname, 'polymer-minimal.json'));
+          path.join(__dirname, 'polymer-minimal.json'));
       assert.deepEqual(options, {});
     });
 
@@ -533,7 +560,8 @@ suite('Project Config', () => {
     });
 
     test('creates config instance from config file options', () => {
-      const config = ProjectConfig.loadConfigFromFile(path.join(__dirname, 'polymer.json'));
+      const config = ProjectConfig.loadConfigFromFile(
+          path.join(__dirname, 'polymer.json'));
       config.validate();
 
       const relativeRoot = 'public';
@@ -554,10 +582,9 @@ suite('Project Config', () => {
       });
     });
 
-
     test('reads a valid config from a file with just {} in it', () => {
       const config = ProjectConfig.loadConfigFromFile(
-        path.join(__dirname, 'polymer-minimal.json'));
+          path.join(__dirname, 'polymer-minimal.json'));
       config.validate();
     });
 

--- a/test/polymer-full.json
+++ b/test/polymer-full.json
@@ -1,0 +1,30 @@
+{
+  "root": "public",
+  "entrypoint": "entrypoint.html",
+  "shell": "shell.html",
+  "fragments": [
+    "fragment.html"
+  ],
+  "extraDependencies": [
+    "extra.html"
+  ],
+  "sources": [
+    "src/**/*",
+    "images/**/*"
+  ],
+  "builds": [
+    {
+      "preset": "es6-bundled"
+    },
+    {
+      "name": "my-build",
+      "swPrecacheConfig": "sw.conf",
+      "browserCapabilities": ["es2015"],
+      "basePath": true
+    }
+  ],
+  "lint": {
+    "rules": ["some-rule"],
+    "ignoreWarnings": ["some-warning"]
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "removeComments": false,
     "preserveConstEnums": true,
     "suppressImplicitAnyIndexErrors": false,
+    "strictNullChecks": true,
     "outDir": "lib",
     "rootDir": "src"
   },


### PR DESCRIPTION
The idea is to dump out the configuration that was used so that prpl-server can read it to figure out what builds to serve. And also maybe it makes some sense to have a record of what options you used for a build.

One problem here is that we have some defaulting logic spread throughout the code, that doesn't update the project config, but usually just updates some local variable. So this isn't quite the full expanded expression of the configuration that maybe we hoped for. It's not... wrong though?

Also clang format.