### PR TITLE
Prepare to release 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
-
+<!-- ## Unreleased -->
 <!-- Add new, unreleased changes here. -->
+
+## [3.2.0] - 2017-05-15
+* Add ProjectConfig toJSON method.
 
 ## [3.1.0] - 2017-05-15
 * Add browserCapabilities and basePath options.

--- a/src/index.ts
+++ b/src/index.ts
@@ -369,8 +369,7 @@ export class ProjectConfig {
   toJSON(): string {
     const relative = (p: string | null | undefined) =>
         p ? path.relative(this.root, p) : undefined;
-    return JSON.stringify({
-      root: this.root,
+    const obj = {
       entrypoint: relative(this.entrypoint),
       shell: relative(this.shell),
       fragments: (this.fragments || []).map(relative),
@@ -378,7 +377,8 @@ export class ProjectConfig {
       extraDependencies: (this.extraDependencies || []).map(relative),
       builds: this.builds,
       lint: this.lint,
-    });
+    };
+    return JSON.stringify(obj, null, 2);
   }
 }
 

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -595,7 +595,6 @@ suite('Project Config', () => {
       const config = ProjectConfig.loadConfigFromFile(
           path.join(__dirname, 'polymer-minimal.json'));
       assert.deepEqual(JSON.parse(config.toJSON()), {
-        root: process.cwd(),
         entrypoint: 'index.html',
         fragments: [],
         sources: [
@@ -610,7 +609,6 @@ suite('Project Config', () => {
       const config = ProjectConfig.loadConfigFromFile(
           path.join(__dirname, 'polymer-full.json'));
       assert.deepEqual(JSON.parse(config.toJSON()), {
-        root: path.resolve('public'),
         entrypoint: 'entrypoint.html',
         shell: 'shell.html',
         fragments: ['fragment.html'],


### PR DESCRIPTION
Also don't emit the root directory. I'm not sure it's useful, since it's just the absolute path of the original build directory, and it breaks the polymer CLI integration test, since it's a random temp directory. Paths are already corrected to be relative to it.

Also add some indentation to the JSON output.