### PR TITLE
Remove insertPrefetchLinks from default presets.

### DIFF
--- a/src/builds.ts
+++ b/src/builds.ts
@@ -66,6 +66,9 @@ export interface ProjectBuildOptions {
    * are prefetched immediately. Add dependency prefetching by inserting `<link
    * rel="prefetch">` tags into entrypoint and `<link rel="import">` tags into
    * fragments and shell for all dependencies.
+   *
+   * Note this option may trigger duplicate requests. See
+   * https://github.com/Polymer/polymer-build/issues/239 for details.
    */
   insertPrefetchLinks?: boolean;
 
@@ -136,7 +139,6 @@ export const buildPresets = new Map<string, ProjectBuildOptions>([
       bundle: true,
       addServiceWorker: true,
       addPushManifest: true,
-      insertPrefetchLinks: true,
     }
   ],
   [
@@ -150,7 +152,6 @@ export const buildPresets = new Map<string, ProjectBuildOptions>([
       bundle: true,
       addServiceWorker: true,
       addPushManifest: true,
-      insertPrefetchLinks: true,
     }
   ],
   [
@@ -164,7 +165,6 @@ export const buildPresets = new Map<string, ProjectBuildOptions>([
       bundle: false,
       addServiceWorker: true,
       addPushManifest: true,
-      insertPrefetchLinks: true,
     }
   ],
 ]);

--- a/test/builds_test.js
+++ b/test/builds_test.js
@@ -51,7 +51,6 @@ suite('builds', () => {
         bundle: true,
         addServiceWorker: true,
         addPushManifest: true,
-        insertPrefetchLinks: true,
       };
       assert.deepEqual(applyBuildPreset(givenBuildConfig), expectedBuildConfig);
     });
@@ -68,7 +67,6 @@ suite('builds', () => {
         bundle: true,
         addServiceWorker: true,
         addPushManifest: true,
-        insertPrefetchLinks: true,
       };
       assert.deepEqual(applyBuildPreset(givenBuildConfig), expectedBuildConfig);
     });
@@ -85,7 +83,6 @@ suite('builds', () => {
         bundle: false,
         addServiceWorker: true,
         addPushManifest: true,
-        insertPrefetchLinks: true,
       };
       assert.deepEqual(applyBuildPreset(givenBuildConfig), expectedBuildConfig);
     });
@@ -100,7 +97,6 @@ suite('builds', () => {
         bundle: false,
         addServiceWorker: false,
         addPushManifest: false,
-        insertPrefetchLinks: false,
       };
       const expectedBuildConfig = {
         preset: 'es5-bundled',
@@ -111,7 +107,6 @@ suite('builds', () => {
         bundle: false,
         addServiceWorker: false,
         addPushManifest: false,
-        insertPrefetchLinks: false,
       };
       assert.deepEqual(applyBuildPreset(givenBuildConfig), expectedBuildConfig);
     });

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -626,7 +626,6 @@ suite('Project Config', () => {
             name: 'es6-bundled',
             addServiceWorker: true,
             addPushManifest: true,
-            insertPrefetchLinks: true,
             bundle: true,
             html: {minify: true},
             css: {minify: true},


### PR DESCRIPTION
As of today, it seems like `insertPrefetchLinks` is causing duplicate requests, e.g. with Shop.

See https://github.com/Polymer/polymer-build/issues/239 for discussion of the underlying issue.

While we figure out whether we need to change strategy, this PR removes `insertPrefetchLinks` from our presets.