### PR TITLE
fix slot relative path when starts with `!`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -367,8 +367,15 @@ export class ProjectConfig {
    * will be relative to root.
    */
   toJSON(): string {
-    const relative = (p: string | null | undefined) =>
-        p ? path.relative(this.root, p) : undefined;
+    const relative = (glob?: string) => {
+      if (glob) {
+        if (glob.startsWith('!')) {
+          return '!' + path.relative(this.root, glob.substr(1));
+        }
+        return path.relative(this.root, glob);
+      }
+      return undefined;
+    };
     const obj = {
       entrypoint: relative(this.entrypoint),
       shell: relative(this.shell),


### PR DESCRIPTION
blocks https://github.com/Polymer/polymer-cli/pull/789

before:
```javascript
"extraDependencies": [
    "manifest.json",
    "service-worker.js",
    "bower_components/webcomponentsjs/*.js",
    "bower_components/webcomponentsjs/*.js.map",
    "!/Projects/polymer-demo/bower_components/webcomponentsjs/gulpfile.js"
  ]
```
after:
```javascript
  "extraDependencies": [
    "manifest.json",
    "service-worker.js",
    "bower_components/webcomponentsjs/*.js",
    "bower_components/webcomponentsjs/*.js.map",
    "!bower_components/webcomponentsjs/gulpfile.js"
  ]
```