### PR TITLE
Feat(bundler-config): Add Object type to bundle option in order to set options in Polymer.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "polymer-project-config",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "reads, validates, and shapes your polymer.json project configuration",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/builds.ts
+++ b/src/builds.ts
@@ -77,7 +77,7 @@ export interface ProjectBuildOptions {
    * reduce the number of file requests. This is optimal for sending to clients
    * or serving from servers that are not HTTP/2 compatible.
    */
-  bundle?: boolean;
+  bundle?: boolean | Object;
 
   /** Options for processing HTML. */
   html?: {


### PR DESCRIPTION
In order to configure the bundler while using the polymer-cli we need to pass an object to the bundle variable

Related to: https://github.com/Polymer/polymer-cli/issues/788