### PR TITLE
Updated the definition of the 'bundle' property to support specific Bundler options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+* Modified the `bundle` property in project build options to support the subset of `polymer-bundler` options which can be serialized in a JSON file.
 <!-- Add new, unreleased changes here. -->
 
 ## [3.3.0] - 2017-06-09

--- a/src/builds.ts
+++ b/src/builds.ts
@@ -98,7 +98,7 @@ export interface ProjectBuildOptions {
     sourcemaps?: boolean,
 
     /**
-     * Remove of all comments except those tagged '@license', or starting with
+     * Remove all comments except those tagged '@license', or starting with
      * `<!--!` or `<!--#`, when true.
      */
     stripComments?: boolean,

--- a/src/builds.ts
+++ b/src/builds.ts
@@ -80,7 +80,29 @@ export interface ProjectBuildOptions {
    * reduce the number of file requests. This is optimal for sending to clients
    * or serving from servers that are not HTTP/2 compatible.
    */
-  bundle?: boolean;
+  bundle?: boolean|{
+
+    /** URLs of files and/or folders that should not be inlined. */
+    excludes?: string[],
+
+    /** Inline external CSS file contents into <style> tags. */
+    inlineCss?: boolean,
+
+    /** Inline external Javascript file contents into <script> tags. */
+    inlineScripts?: boolean,
+
+    /** Rewrite element attributes inside of templates when inlining html. */
+    rewriteUrlsInTemplates?: boolean,
+
+    /** Create identity source maps for inline scripts. */
+    sourcemaps?: boolean,
+
+    /**
+     * Remove of all comments except those tagged '@license', or starting with
+     * `<!--!` or `<!--#`, when true.
+     */
+    stripComments?: boolean,
+  };
 
   /** Options for processing HTML. */
   html?: {


### PR DESCRIPTION
 - One half of the fix to https://github.com/Polymer/polymer-cli/issues/788
 - When https://github.com/Polymer/polymer-cli/pull/806 lands, it will handle this new config value.  In the meantime the new value will be accepted, but its details will be ignored (it will continue to just apply bundler defaults until new CLI is released.
 - Previously the bundle property of a build definition was limited to true|false. Now it can also be a bag of the options for bundler, so we can support 1.x projects that need rewriteUrlsInTemplates behavior or turn off script inlining or css inlining etc.
 - [x] CHANGELOG updated.