### PR TITLE
Prepare release of polymer-project-config 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-* Modified the `bundle` property in project build options to support the subset of `polymer-bundler` options which can be serialized in a JSON file.
 <!-- Add new, unreleased changes here. -->
+
+## [3.4.0] - 2017-06-21
+* Modified the `bundle` property in project build options to support the subset of `polymer-bundler` options which can be serialized in a JSON file.
 
 ## [3.3.0] - 2017-06-09
 * Removed `insertPrefetchLinks` from build presets. See https://github.com/Polymer/polymer-build/issues/239 for details.


### PR DESCRIPTION
* Minor release 3.3.0 -> 3.4.0 because update to the type value of bundle is significant enough to warrant IMO.
* Modified the `bundle` property in project build options to support the subset of `polymer-bundler` options which can be serialized in a JSON file.
* `bundle` property used to just be a `boolean`.  Now it can be boolean OR an object bag of settings matching (most-of) the polymer-bundler constructor options:
```typescript
  bundle?: boolean|{

    /** URLs of files and/or folders that should not be inlined. */
    excludes?: string[],

    /** Inline external CSS file contents into <style> tags. */
    inlineCss?: boolean,

    /** Inline external Javascript file contents into <script> tags. */
    inlineScripts?: boolean,

    /** Rewrite element attributes inside of templates when inlining html. */
    rewriteUrlsInTemplates?: boolean,

    /** Create identity source maps for inline scripts. */
    sourcemaps?: boolean,

    /**
     * Remove all comments except those tagged '@license', or starting with
     * `<!--!` or `<!--#`, when true.
     */
    stripComments?: boolean,
  };
```
* Note: this new config is compatible with existing configs in that the only handling of the `bundle` option thus-far has been in the `polymer-cli` which does general truthiness check one value, so introducing an Object will just be treated as `true` for purposes of un-upgraded versions of the CLI so this is NOT a BREAKING change.