### PR TITLE
Support validating objects in memory. Prepare v3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+<!-- ## Unreleased -->
 <!-- Add new, unreleased changes here. -->
+
+## [3.5.0] - 2017-11-21
+* Added static methods for constructing a ProjectConfig directly from an unvalidated JSON object, in addition to the methods for reading it from disk.
 
 ## [3.4.0] - 2017-06-21
 * Modified the `bundle` property in project build options to support the subset of `polymer-bundler` options which can be serialized in a JSON file.


### PR DESCRIPTION
The editor service needs to handle loading polymer.json from disk itself, as the polymer.json object may change from editing an in memory document.