### PR TITLE
Add autoBasePath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
 <!-- Add new, unreleased changes here. -->
+* Added new option: `autoBasePath`. This new flag sets `basePath: true` on all builds. See that option for more details.
 
 ## [3.6.0] - 2017-11-28
 * Added a new lint option: `filesToIgnore`. We'll never report warnings for any
@@ -15,7 +16,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
     spelling which will be used preferentially. This was better than making the
     options inconsistent, or spelling the new option `ignoreFiles`.
 * Improved error messages when validation of a polymer.json object fails.
-<!-- Add new, unreleased changes here. -->
 
 ## [3.5.0] - 2017-11-21
 * Added static methods for constructing a ProjectConfig directly from an unvalidated JSON object, in addition to the methods for reading it from disk.

--- a/src/index.ts
+++ b/src/index.ts
@@ -355,11 +355,9 @@ export class ProjectConfig {
      */
     if (options.autoBasePath) {
       this.autoBasePath = options.autoBasePath;
-      if (Array.isArray(this.builds)) {
-        this.builds = this.builds.map((build: ProjectBuildOptions) => {
-          build.basePath = true;
-          return build;
-        });
+
+      for (const build of this.builds || []) {
+        build.basePath = true;
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,7 @@ export interface ProjectOptions {
   builds?: ProjectBuildOptions[];
 
   /**
-   * Tag all build with `basePath: true`.
+   * Set `basePath: true` on all builds. See that option for more details.
    */
   autoBasePath?: boolean;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -355,6 +355,12 @@ export class ProjectConfig {
      */
     if (options.autoBasePath) {
       this.autoBasePath = options.autoBasePath;
+      if (Array.isArray(this.builds)) {
+        this.builds = this.builds.map((build: ProjectBuildOptions) => {
+          build.basePath = true;
+          return build;
+        });
+      }
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,11 @@ export interface ProjectOptions {
   builds?: ProjectBuildOptions[];
 
   /**
+   * Tag all build with `basePath: true`.
+   */
+  autoBasePath?: boolean;
+
+  /**
    * Options for the Polymer Linter.
    */
   lint?: LintOptions;
@@ -180,6 +185,7 @@ export class ProjectConfig {
   readonly extraDependencies: string[];
 
   readonly builds: ProjectBuildOptions[];
+  readonly autoBasePath: boolean;
   readonly allFragments: string[];
   readonly lint: LintOptions|undefined = undefined;
 
@@ -343,6 +349,13 @@ export class ProjectConfig {
         this.builds = this.builds.map(applyBuildPreset);
       }
     }
+
+    /**
+     * autoBasePath
+     */
+    if (options.autoBasePath) {
+      this.autoBasePath = options.autoBasePath;
+    }
   }
 
   isFragment(filepath: string): boolean {
@@ -451,6 +464,7 @@ export class ProjectConfig {
         return globRelative(this.root, absolutePath);
       }),
       builds: this.builds,
+      autoBasePath: this.autoBasePath,
       lint: lintObj,
     };
     return JSON.stringify(obj, null, 2);

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -593,7 +593,7 @@ suite('Project Config', () => {
   suite('json validation', () => {
     test('throws good error messages', () => {
       try {
-        ProjectConfig.validateAndCreate({ lint: [] });
+        ProjectConfig.validateAndCreate({lint: []});
       } catch (e) {
         assert.deepEqual(
             e.message, `Property 'lint' is not of a type(s) object`);
@@ -655,7 +655,7 @@ suite('Project Config', () => {
         lint: {
           rules: ['some-rule'],
           warningsToIgnore: ['some-warning'],
-          filesToIgnore: ["some .* glob"]
+          filesToIgnore: ['some .* glob']
         }
       });
     });

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -593,7 +593,7 @@ suite('Project Config', () => {
   suite('json validation', () => {
     test('throws good error messages', () => {
       try {
-        ProjectConfig.validateAndCreate({lint: []});
+        ProjectConfig.validateAndCreate({ lint: [] });
       } catch (e) {
         assert.deepEqual(
             e.message, `Property 'lint' is not of a type(s) object`);
@@ -655,7 +655,7 @@ suite('Project Config', () => {
         lint: {
           rules: ['some-rule'],
           warningsToIgnore: ['some-warning'],
-          filesToIgnore: ['some .* glob']
+          filesToIgnore: ["some .* glob"]
         }
       });
     });


### PR DESCRIPTION
This new flag sets the entrypoint `<base>` tag for all builds to match the name of that build. Unlike the other flags, it does not necessarily trigger a single one-off build. Instead, it switches the option on for all builds (including a one-off, if another flag triggered one).

The idea is to make building for prpl-server easier. See Polymer/prpl-server-node#24 for motivation. Right now you need need to annotate each build in your `polymer.json` with `basePath: true` to make prpl-server work. The problem with this is that:

Reference: https://github.com/Polymer/polymer-cli/pull/920