### PR TITLE
Rename `excludes` to `exclude` for the `js-minify`, `js-compile`, `css-minify` and `html-minify` options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-<!-- Add new, unreleased changes here. -->
-
-## [3.8.1] - 2018-01-29
 * Changed name of `excludes` property to more natural `exclude` in `js-minify`, `js-compile`, `css-minify` and `html-minify` options prior to releasing the feature as `exclude` is more natural.  The `bundle` options will remain `excludes` for now, as that is already implemented in `polymer-bundler`.
+<!-- Add new, unreleased changes here. -->
 
 ## [3.8.0] - 2018-01-23
 * Updated the `build` options `js-minify`, `js-compile`, `css-minify` and `html-minify` to support an object with `excludes` property to list specific files to exclude from minification or compilation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 <!-- Add new, unreleased changes here. -->
 
+## [3.8.1] - 2018-01-29
+* Changed name of `excludes` property to more natural `exclude` in `js-minify`, `js-compile`, `css-minify` and `html-minify` options prior to releasing the feature as `exclude` is more natural.  The `bundle` options will remain `excludes` for now, as that is already implemented in `polymer-bundler`.
+
 ## [3.8.0] - 2018-01-23
 * Updated the `build` options `js-minify`, `js-compile`, `css-minify` and `html-minify` to support an object with `excludes` property to list specific files to exclude from minification or compilation.
 

--- a/src/builds.ts
+++ b/src/builds.ts
@@ -109,7 +109,7 @@ export interface ProjectBuildOptions {
     /** Minify HTMl by removing comments and whitespace. */
     minify?: boolean|{
       /** HTML files listed here will not be minified. */
-      excludes?: string[],
+      exclude?: string[],
     },
   };
 
@@ -118,7 +118,7 @@ export interface ProjectBuildOptions {
     /** Minify inlined and external CSS. */
     minify?: boolean|{
       /** CSS files listed here will not be minified. */
-      excludes?: string[],
+      exclude?: string[],
     },
   };
 
@@ -127,13 +127,13 @@ export interface ProjectBuildOptions {
     /** Minify inlined and external JavaScript. */
     minify?: boolean|{
       /** JavaScript files listed here will not be minified. */
-      excludes?: string[],
+      exclude?: string[],
     },
 
     /** Use babel to compile all ES6 JS down to ES5 for older browsers. */
     compile?: boolean|{
       /** JavaScript files listed here will not be compiled. */
-      excludes?: string[],
+      exclude?: string[],
     }
   };
 

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -652,7 +652,7 @@ suite('Project Config', () => {
             basePath: true,
             html: {
               minify: {
-                excludes: [
+                exclude: [
                   'human-readable-example.html',
                   'weird-ie-comments-issue.html'
                 ]
@@ -660,7 +660,7 @@ suite('Project Config', () => {
             },
             css: {
               minify: {
-                excludes: [
+                exclude: [
                   'css/human-readable-example.css',
                   'css/advanced-syntax.css'
                 ]
@@ -668,13 +668,13 @@ suite('Project Config', () => {
             },
             js: {
               minify: {
-                excludes: [
+                exclude: [
                   'js/unminifiable.js',
                   'js/already-minified.js'
                 ]
               }, 
               compile: {
-                excludes: [
+                exclude: [
                   'js/breaks-when-compiled.js',
                   'js/no-compilation-necessary.js'
                 ]

--- a/test/polymer-full.json
+++ b/test/polymer-full.json
@@ -25,20 +25,20 @@
       "basePath": true,
       "js": {
         "compile": {
-          "excludes": ["js/breaks-when-compiled.js", "js/no-compilation-necessary.js"]
+          "exclude": ["js/breaks-when-compiled.js", "js/no-compilation-necessary.js"]
         },
         "minify": {
-          "excludes": ["js/unminifiable.js", "js/already-minified.js"]
+          "exclude": ["js/unminifiable.js", "js/already-minified.js"]
         }
       },
       "html": {
         "minify": {
-          "excludes": ["human-readable-example.html", "weird-ie-comments-issue.html"]
+          "exclude": ["human-readable-example.html", "weird-ie-comments-issue.html"]
         }
       },
       "css": {
         "minify": {
-          "excludes": ["css/human-readable-example.css", "css/advanced-syntax.css"]
+          "exclude": ["css/human-readable-example.css", "css/advanced-syntax.css"]
         }
       }
     }


### PR DESCRIPTION
Changed name of `excludes` property to more natural `exclude` in `js-minify`, `js-compile`, `css-minify` and `html-minify` options prior to releasing the feature as `exclude` is more natural.  The `bundle` options will remain `excludes` for now, as that is already implemented in `polymer-bundler`.